### PR TITLE
revert: tumor mutational burden

### DIFF
--- a/src/pages/patientView/clinicalInformation/lib/clinicalAttributesStyleConsts.ts
+++ b/src/pages/patientView/clinicalInformation/lib/clinicalAttributesStyleConsts.ts
@@ -161,13 +161,6 @@ export const config: { [key: string]: configAttribute } = {
         primary: true,
         order: 6,
     },
-    TUMOR_MUTATIONAL_BURDEN: {
-        primary: true,
-        formatter: (t: string) => {
-            return `TMB: ${t}%`;
-        },
-        order: 6,
-    },
     TUMOR_STAGE_2009: {
         primary: true,
         order: 6,


### PR DESCRIPTION
As discussed, the MSK implemented this feature themselves. So this is getting redundant.