### PR TITLE
Follow up tab

### DIFF
--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -93,6 +93,7 @@ import { OtherBiomarkersQueryType } from 'react-mutation-mapper';
 import { OtherBiomarkerAnnotation } from 'pages/patientView/oncokb/OtherBiomarkerAnnotation';
 import MutationalSignaturesContainer from './mutationalSignatures/MutationalSignaturesContainer';
 import SampleSummaryList from './sampleHeader/SampleSummaryList';
+import FollowUpTable from './therapyRecommendation/FollowUpTable';
 
 export interface IPatientViewPageProps {
     params: any; // react route
@@ -393,6 +394,12 @@ export default class PatientViewPage extends React.Component<
         return true;
     }
 
+    private shouldShowFollowUpTab(
+        patientViewPageStore: PatientViewPageStore
+    ): boolean {
+        return true;
+    }
+
     @autobind
     private customTabMountCallback(div: HTMLDivElement, tab: any) {
         showCustomTab(
@@ -548,32 +555,25 @@ export default class PatientViewPage extends React.Component<
             const resourceDataById = this.patientViewPageStore
                 .resourceIdToResourceData.result!;
 
-            const tabs: JSX.Element[] = sorted.reduce(
-                (list, def) => {
-                    const data = resourceDataById[def.resourceId];
-                    if (data && data.length > 0) {
-                        list.push(
-                            <MSKTab
-                                key={getPatientViewResourceTabId(
-                                    def.resourceId
-                                )}
-                                id={getPatientViewResourceTabId(def.resourceId)}
-                                linkText={def.displayName}
-                                onClickClose={this.closeResourceTab}
-                            >
-                                <ResourceTab
-                                    resourceData={
-                                        resourceDataById[def.resourceId]
-                                    }
-                                    urlWrapper={this.urlWrapper}
-                                />
-                            </MSKTab>
-                        );
-                    }
-                    return list;
-                },
-                [] as JSX.Element[]
-            );
+            const tabs: JSX.Element[] = sorted.reduce((list, def) => {
+                const data = resourceDataById[def.resourceId];
+                if (data && data.length > 0) {
+                    list.push(
+                        <MSKTab
+                            key={getPatientViewResourceTabId(def.resourceId)}
+                            id={getPatientViewResourceTabId(def.resourceId)}
+                            linkText={def.displayName}
+                            onClickClose={this.closeResourceTab}
+                        >
+                            <ResourceTab
+                                resourceData={resourceDataById[def.resourceId]}
+                                urlWrapper={this.urlWrapper}
+                            />
+                        </MSKTab>
+                    );
+                }
+                return list;
+            }, [] as JSX.Element[]);
             return tabs;
         },
     });
@@ -1725,6 +1725,105 @@ export default class PatientViewPage extends React.Component<
                                                     this.patientViewPageStore
                                                         .pubMedCache
                                                 }
+                                            />
+                                        </MSKTab>
+                                    )}
+
+                                {this.shouldShowFollowUpTab(
+                                    this.patientViewPageStore
+                                ) &&
+                                    this.patientViewPageStore.mutationData
+                                        .isComplete &&
+                                    this.patientViewPageStore.discreteCNAData
+                                        .isComplete &&
+                                    (this.patientViewPageStore.oncoKbData
+                                        .isComplete ||
+                                        this.patientViewPageStore.oncoKbData
+                                            .isError) &&
+                                    (this.patientViewPageStore.mtbs
+                                        .isComplete ||
+                                        this.patientViewPageStore.mtbs
+                                            .isError) &&
+                                    (this.patientViewPageStore.cnaOncoKbData
+                                        .isComplete ||
+                                        this.patientViewPageStore.cnaOncoKbData
+                                            .isError) && (
+                                        <MSKTab
+                                            key={43}
+                                            id={PatientViewPageTabs.FollowUp}
+                                            linkText="Follow-up"
+                                            unmountOnHide={true}
+                                        >
+                                            <FollowUpTable
+                                                patientId={
+                                                    this.patientViewPageStore
+                                                        .patientId
+                                                }
+                                                mutations={
+                                                    this.patientViewPageStore
+                                                        .mutationData.result
+                                                }
+                                                indexedVariantAnnotations={
+                                                    this.patientViewPageStore
+                                                        .indexedVariantAnnotations
+                                                        .result
+                                                }
+                                                indexedMyVariantInfoAnnotations={
+                                                    this.patientViewPageStore
+                                                        .indexedMyVariantInfoAnnotations
+                                                        .result
+                                                }
+                                                cna={
+                                                    this.patientViewPageStore
+                                                        .discreteCNAData.result
+                                                }
+                                                clinicalData={this.patientViewPageStore.clinicalDataPatient.result.concat(
+                                                    this.patientViewPageStore
+                                                        .clinicalDataForSamples
+                                                        .result
+                                                )}
+                                                sampleManager={sampleManager}
+                                                oncoKbAvailable={
+                                                    AppConfig.serverConfig
+                                                        .show_oncokb &&
+                                                    !this.patientViewPageStore
+                                                        .cnaOncoKbData
+                                                        .isError &&
+                                                    !this.patientViewPageStore
+                                                        .oncoKbData.isError
+                                                }
+                                                mtbs={
+                                                    this.patientViewPageStore
+                                                        .mtbs.result
+                                                }
+                                                deletions={
+                                                    this.patientViewPageStore
+                                                        .deletions
+                                                }
+                                                containerWidth={
+                                                    WindowStore.size.width - 20
+                                                }
+                                                onDeleteData={
+                                                    this.patientViewPageStore
+                                                        .deleteFollowUps
+                                                }
+                                                onSaveData={
+                                                    this.patientViewPageStore
+                                                        .updateFollowUps
+                                                }
+                                                oncoKbData={
+                                                    this.patientViewPageStore
+                                                        .oncoKbData
+                                                }
+                                                cnaOncoKbData={
+                                                    this.patientViewPageStore
+                                                        .cnaOncoKbData
+                                                }
+                                                pubMedCache={
+                                                    this.patientViewPageStore
+                                                        .pubMedCache
+                                                }
+                                                followUps={[]}
                                             />
                                         </MSKTab>
                                     )}

--- a/src/pages/patientView/PatientViewPageTabs.ts
+++ b/src/pages/patientView/PatientViewPageTabs.ts
@@ -10,6 +10,7 @@ export enum PatientViewPageTabs {
     MutationalSignatures = 'mutationalSignatures',
     TherapyRecommendation = 'therapyRecommendation',
     Mtb = 'mtb',
+    FollowUp = 'followUp',
     ClinicalTrialsGov = 'clinicaltrialsGov',
 }
 

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -190,7 +190,11 @@ import {
     MutationalSignatureStableIdKeyWord,
 } from 'shared/lib/GenericAssayUtils/MutationalSignaturesUtils';
 
-import { IMtb, IDeletions } from '../../../shared/model/TherapyRecommendation';
+import {
+    IMtb,
+    IDeletions,
+    IFollowUp,
+} from '../../../shared/model/TherapyRecommendation';
 import {
     StudyListEntry,
     StudyList,
@@ -2275,9 +2279,21 @@ export class PatientViewPageStore {
         );
     };
 
+    updateFollowUps = (followUps: IFollowUp[]) => {
+        console.log('update');
+        // TODO
+
+        // updateMtbUsingPUT(
+        //     this.getSafePatientId(),
+        //     this.getMtbJsonStoreUrl(this.getSafePatientId()),
+        //     mtbs
+        // );
+    };
+
     readonly deletions: IDeletions = {
         mtb: [],
         therapyRecommendation: [],
+        followUp: [],
     };
 
     deleteMtbs = (deletions: IDeletions) => {
@@ -2287,6 +2303,17 @@ export class PatientViewPageStore {
             this.getMtbJsonStoreUrl(this.getSafePatientId()),
             deletions
         );
+    };
+
+    deleteFollowUps = (deletions: IDeletions) => {
+        console.log('delete');
+        // TODO
+
+        // deleteMtbUsingDELETE(
+        //     this.getSafePatientId(),
+        //     this.getMtbJsonStoreUrl(this.getSafePatientId()),
+        //     deletions
+        // );
     };
 
     private getMtbJsonStoreUrl(id: string) {

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -221,6 +221,9 @@ import {
     fetchMtbsUsingGET,
     updateMtbUsingPUT,
     deleteMtbUsingDELETE,
+    fetchFollowupUsingGET,
+    updateFollowupUsingPUT,
+    deleteFollowupUsingDELETE,
 } from 'shared/api/TherapyRecommendationAPI';
 import { RecruitingStatus } from 'shared/enums/ClinicalTrialsGovRecruitingStatus';
 import { ageAsNumber } from '../clinicalTrialMatch/utils/AgeSexConverter';
@@ -2270,6 +2273,19 @@ export class PatientViewPageStore {
         []
     );
 
+    readonly followups = remoteData<IFollowUp[]>(
+        {
+            invoke: () => {
+                return fetchFollowupUsingGET(
+                    this.getMtbJsonStoreUrl(
+                        'followup/' + this.getSafePatientId()
+                    )
+                );
+            },
+        },
+        []
+    );
+
     updateMtbs = (mtbs: IMtb[]) => {
         console.log('update');
         updateMtbUsingPUT(
@@ -2281,13 +2297,12 @@ export class PatientViewPageStore {
 
     updateFollowUps = (followUps: IFollowUp[]) => {
         console.log('update');
-        // TODO
 
-        // updateMtbUsingPUT(
-        //     this.getSafePatientId(),
-        //     this.getMtbJsonStoreUrl(this.getSafePatientId()),
-        //     mtbs
-        // );
+        updateFollowupUsingPUT(
+            this.getSafePatientId(),
+            this.getMtbJsonStoreUrl('followup/' + this.getSafePatientId()),
+            followUps
+        );
     };
 
     readonly deletions: IDeletions = {
@@ -2307,13 +2322,11 @@ export class PatientViewPageStore {
 
     deleteFollowUps = (deletions: IDeletions) => {
         console.log('delete');
-        // TODO
-
-        // deleteMtbUsingDELETE(
-        //     this.getSafePatientId(),
-        //     this.getMtbJsonStoreUrl(this.getSafePatientId()),
-        //     deletions
-        // );
+        deleteFollowupUsingDELETE(
+            this.getSafePatientId(),
+            this.getMtbJsonStoreUrl('followup/' + this.getSafePatientId()),
+            deletions
+        );
     };
 
     private getMtbJsonStoreUrl(id: string) {

--- a/src/pages/patientView/therapyRecommendation/FollowUpTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/FollowUpTable.tsx
@@ -1,0 +1,337 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import * as _ from 'lodash';
+import {
+    ITherapyRecommendation,
+    IFollowUp,
+    MtbState,
+    IDeletions,
+    IMtb,
+} from '../../../shared/model/TherapyRecommendation';
+import { computed, observable } from 'mobx';
+import LazyMobXTable from '../../../shared/components/lazyMobXTable/LazyMobXTable';
+import styles from './style/therapyRecommendation.module.scss';
+import SampleManager from '../SampleManager';
+import {
+    flattenStringify,
+    getAuthor,
+    getTooltipAuthorContent,
+} from './TherapyRecommendationTableUtils';
+import { Button } from 'react-bootstrap';
+import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import {
+    Mutation,
+    ClinicalData,
+    DiscreteCopyNumberData,
+} from 'cbioportal-ts-api-client';
+import { SimpleCopyDownloadControls } from 'shared/components/copyDownloadControls/SimpleCopyDownloadControls';
+import { RemoteData, IOncoKbData } from 'cbioportal-utils';
+import PubMedCache from 'shared/cache/PubMedCache';
+import LabeledCheckbox from 'shared/components/labeledCheckbox/LabeledCheckbox';
+import WindowStore from 'shared/components/window/WindowStore';
+import MtbTherapyRecommendationTable from './MtbTherapyRecommendationTable';
+import Select from 'react-select';
+import { VariantAnnotation, MyVariantInfo } from 'genome-nexus-ts-api-client';
+import FollowUpForm from './form/FollowUpForm';
+import AppConfig from 'appConfig';
+
+export type IFollowUpProps = {
+    patientId: string;
+    mutations: Mutation[];
+    indexedVariantAnnotations:
+        | { [genomicLocation: string]: VariantAnnotation }
+        | undefined;
+    indexedMyVariantInfoAnnotations:
+        | { [genomicLocation: string]: MyVariantInfo }
+        | undefined;
+    cna: DiscreteCopyNumberData[];
+    clinicalData: ClinicalData[];
+    sampleManager: SampleManager | null;
+    oncoKbAvailable: boolean;
+    followUps: IFollowUp[];
+    mtbs: IMtb[];
+    deletions: IDeletions;
+    containerWidth: number;
+    onDeleteData: (deletions: IDeletions) => void;
+    onSaveData: (followUps: IFollowUp[]) => void;
+    oncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
+    cnaOncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
+    pubMedCache?: PubMedCache;
+};
+
+export type IFollowUpState = {
+    followUps: IFollowUp[];
+    deletions: IDeletions;
+};
+
+enum ColumnKey {
+    INFO = 'Follow-up',
+    THERAPYRECOMMENDATION = 'Therapy Recommendation',
+}
+
+enum ColumnWidth {
+    INFO = 140,
+}
+
+class FollowUpTableComponent extends LazyMobXTable<IFollowUp> {}
+
+@observer
+export default class FollowUpTable extends React.Component<
+    IFollowUpProps,
+    IFollowUpState
+> {
+    constructor(props: IFollowUpProps) {
+        super(props);
+        this.state = {
+            followUps: props.followUps,
+            deletions: props.deletions,
+        };
+    }
+
+    @computed
+    get columnWidths() {
+        return {
+            [ColumnKey.INFO]: ColumnWidth.INFO,
+            [ColumnKey.THERAPYRECOMMENDATION]:
+                this.props.containerWidth - ColumnWidth.INFO,
+        };
+    }
+
+    @observable selectedTherapyRecommendation:
+        | ITherapyRecommendation
+        | undefined;
+    @observable backupTherapyRecommendation: ITherapyRecommendation | undefined;
+    @observable showFollowUpForm: boolean;
+
+    private _columns = [
+        {
+            name: ColumnKey.INFO,
+            render: (followUp: IFollowUp) => (
+                <div>
+                    <span className={styles.edit}>
+                        <DefaultTooltip
+                            trigger={['hover', 'focus']}
+                            overlay={getTooltipAuthorContent(
+                                'Follow-up',
+                                followUp.author
+                            )}
+                            destroyTooltipOnHide={false}
+                        >
+                            <i className={'fa fa-user-circle'}></i>
+                        </DefaultTooltip>
+                    </span>
+                    <input
+                        type="date"
+                        value={followUp.date}
+                        style={{
+                            display: 'block',
+                            marginTop: '2px',
+                            marginBottom: '2px',
+                        }}
+                        onChange={(e: React.FormEvent<HTMLInputElement>) => {
+                            const newDate = e.currentTarget.value;
+                            const newFollowUps = this.state.followUps.slice();
+                            newFollowUps.find(
+                                x => x.id === followUp.id
+                            )!.date = newDate;
+                            this.setState({ followUps: newFollowUps });
+                        }}
+                    ></input>
+                    <LabeledCheckbox
+                        checked={followUp.therapyRecommendationRealized}
+                        onChange={() => {
+                            const newTrr = !followUp.therapyRecommendationRealized;
+                            const newFollowUps = this.state.followUps.slice();
+                            newFollowUps.find(
+                                x => x.id === followUp.id
+                            )!.therapyRecommendationRealized = newTrr;
+                            this.setState({ followUps: newFollowUps });
+                        }}
+                        labelProps={{ style: { marginRight: 10 } }}
+                    >
+                        <span style={{ marginTop: '-2px' }}>Realized</span>
+                    </LabeledCheckbox>
+                    <textarea
+                        title="Comments"
+                        rows={4}
+                        cols={30}
+                        value={followUp.comment}
+                        placeholder="Comments"
+                        onChange={(
+                            e: React.ChangeEvent<HTMLTextAreaElement>
+                        ) => {
+                            const newComment = e.target.value;
+                            const newFollowUps = this.state.followUps.slice();
+                            newFollowUps.find(
+                                x => x.id === followUp.id
+                            )!.comment = newComment;
+                            this.setState({ followUps: newFollowUps });
+                        }}
+                    />
+                    <span className={styles.edit}>
+                        <Button
+                            type="button"
+                            className={'btn btn-default ' + styles.deleteButton}
+                            onClick={() =>
+                                window.confirm(
+                                    'Are you sure you wish to delete this follow-up?'
+                                ) && this.deleteFollowUp(followUp)
+                            }
+                        >
+                            <i
+                                className={`fa fa-trash ${styles.marginLeft}`}
+                                aria-hidden="true"
+                            ></i>{' '}
+                            Delete
+                        </Button>
+                    </span>
+                </div>
+            ),
+            width: this.columnWidths[ColumnKey.INFO],
+        },
+        {
+            name: ColumnKey.THERAPYRECOMMENDATION,
+            render: (followUp: IFollowUp) => (
+                <MtbTherapyRecommendationTable
+                    patientId={this.props.patientId}
+                    mutations={this.props.mutations}
+                    indexedVariantAnnotations={
+                        this.props.indexedVariantAnnotations
+                    }
+                    indexedMyVariantInfoAnnotations={
+                        this.props.indexedMyVariantInfoAnnotations
+                    }
+                    cna={this.props.cna}
+                    clinicalData={this.props.clinicalData}
+                    sampleManager={this.props.sampleManager}
+                    oncoKbAvailable={this.props.oncoKbAvailable}
+                    therapyRecommendations={[followUp.therapyRecommendation]}
+                    containerWidth={WindowStore.size.width - 20}
+                    oncoKbData={this.props.oncoKbData}
+                    cnaOncoKbData={this.props.cnaOncoKbData}
+                    pubMedCache={this.props.pubMedCache}
+                    isDisabled={false}
+                    showButtons={false}
+                    columnVisibility={{
+                        Reasoning: true,
+                        Therapy: true,
+                        Comment: true,
+                        'Evidence Level': true,
+                        References: true,
+                    }}
+                />
+            ),
+            width: this.columnWidths[ColumnKey.THERAPYRECOMMENDATION],
+        },
+    ];
+
+    private onHideFollowUpForm(therapyRecommendation: ITherapyRecommendation) {
+        this.showFollowUpForm = false;
+        console.log(flattenStringify(this.props.mtbs));
+        therapyRecommendation && this.addFollowUp(therapyRecommendation);
+    }
+
+    private addFollowUp(therapyRecommendation: ITherapyRecommendation) {
+        const now = new Date();
+        const newFollowUps = this.state.followUps.slice();
+        const newFollowUp = {
+            id: 'followUp_' + this.props.patientId + '_' + now.getTime(),
+            therapyRecommendation: therapyRecommendation,
+            date: now.toISOString().split('T')[0],
+            author: getAuthor(),
+            comment: '',
+            therapyRecommendationRealized: false,
+        } as IFollowUp;
+        newFollowUps.push(newFollowUp);
+        this.setState({ followUps: newFollowUps });
+    }
+
+    private deleteFollowUp(followUpToDelete: IFollowUp) {
+        this.state.deletions.followUp.push(followUpToDelete.id);
+        const newFollowUps = this.state.followUps
+            .slice()
+            .filter(
+                (followUp: IFollowUp) => followUpToDelete.id !== followUp.id
+            );
+        this.setState({ followUps: newFollowUps });
+    }
+
+    private saveFollowUps() {
+        if (
+            this.state.deletions.followUp.length > 0 ||
+            this.state.deletions.therapyRecommendation.length > 0
+        ) {
+            console.log('Save deletions');
+            this.props.onDeleteData(this.state.deletions);
+        }
+        console.group('Save followUps');
+        this.props.onSaveData(this.state.followUps);
+        console.groupEnd();
+    }
+
+    private test() {
+        console.group('Test');
+        console.log(this.props);
+        console.groupEnd();
+    }
+
+    render() {
+        return (
+            <div>
+                <h2 style={{ marginBottom: '0' }}>Follow-up data</h2>
+                <p className={styles.edit}>
+                    <Button
+                        type="button"
+                        className={
+                            'btn btn-default ' + styles.addFollowUpButton
+                        }
+                        onClick={() => (this.showFollowUpForm = true)}
+                    >
+                        <i
+                            className={`fa fa-plus ${styles.marginLeft}`}
+                            aria-hidden="true"
+                        ></i>{' '}
+                        Add Follow-up
+                    </Button>
+                    <Button
+                        type="button"
+                        className={'btn btn-default ' + styles.testButton}
+                        onClick={() => this.saveFollowUps()}
+                    >
+                        Save Data
+                    </Button>
+                    {/* <Button type="button" className={"btn btn-default " + styles.testButton} onClick={() => this.test()}>Test</Button> */}
+                    {this.showFollowUpForm && (
+                        <FollowUpForm
+                            show={this.showFollowUpForm}
+                            patientID={this.props.patientId}
+                            mtbs={this.props.mtbs}
+                            onHide={(
+                                therapyRecommendation: ITherapyRecommendation
+                            ) => {
+                                this.onHideFollowUpForm(therapyRecommendation);
+                            }}
+                            title="Select therapy recommendation"
+                            userEmailAddress={
+                                AppConfig.serverConfig.user_email_address
+                            }
+                        />
+                    )}
+                </p>
+                <FollowUpTableComponent
+                    data={this.state.followUps}
+                    columns={this._columns}
+                    showCopyDownload={false}
+                    showFilter={false}
+                    showColumnVisibility={false}
+                    className="followUp-table"
+                />
+                <SimpleCopyDownloadControls
+                    downloadData={() => flattenStringify(this.state.followUps)}
+                    downloadFilename={`followUp_${this.props.patientId}.json`}
+                    controlsStyle="BUTTON"
+                />
+            </div>
+        );
+    }
+}

--- a/src/pages/patientView/therapyRecommendation/FollowUpTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/FollowUpTable.tsx
@@ -7,6 +7,7 @@ import {
     MtbState,
     IDeletions,
     IMtb,
+    IResponseCriteria,
 } from '../../../shared/model/TherapyRecommendation';
 import { computed, observable } from 'mobx';
 import LazyMobXTable from '../../../shared/components/lazyMobXTable/LazyMobXTable';
@@ -153,7 +154,125 @@ export default class FollowUpTable extends React.Component<
                         <span style={{ marginTop: '-2px' }}>Realized</span>
                     </LabeledCheckbox>
                     <Collapse isOpened={followUp.therapyRecommendationRealized}>
+                        <LabeledCheckbox
+                            checked={followUp.sideEffect}
+                            onChange={() => {
+                                const newTrr = !followUp.sideEffect;
+                                const newFollowUps = this.state.followUps.slice();
+                                newFollowUps.find(
+                                    x => x.id === followUp.id
+                                )!.sideEffect = newTrr;
+                                this.setState({ followUps: newFollowUps });
+                            }}
+                            labelProps={{ style: { marginRight: 10 } }}
+                        >
+                            <span style={{ marginTop: '-2px' }}>
+                                Side effect
+                            </span>
+                        </LabeledCheckbox>
                         <span>Tumor response criteria</span>
+                        <table>
+                            <tr>
+                                <th>Months</th>
+                                <th>PD</th>
+                                <th>SD</th>
+                                <th>PR</th>
+                                <th>CR</th>
+                            </tr>
+                            <tr>
+                                <td>3</td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'pd3'
+                                    )}
+                                </td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'sd3'
+                                    )}
+                                </td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'pr3'
+                                    )}
+                                </td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'cr3'
+                                    )}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>6</td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'pd6'
+                                    )}
+                                </td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'sd6'
+                                    )}
+                                </td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'pr6'
+                                    )}
+                                </td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'cr6'
+                                    )}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>12</td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'pd12'
+                                    )}
+                                </td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'sd12'
+                                    )}
+                                </td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'pr12'
+                                    )}
+                                </td>
+                                <td>
+                                    {this.getTreatmentResponseCheckbox(
+                                        followUp,
+                                        followUp.response,
+                                        'cr12'
+                                    )}
+                                </td>
+                            </tr>
+                        </table>
                     </Collapse>
                     <textarea
                         title="Comments"
@@ -238,6 +357,21 @@ export default class FollowUpTable extends React.Component<
     private addFollowUp(therapyRecommendation: ITherapyRecommendation) {
         const now = new Date();
         const newFollowUps = this.state.followUps.slice();
+        // const emptyResponseCriteria = {pd: false, sd: false, pr: false, cr: false} as IResponseCriteria;
+        const emptyResponseCriteria = {
+            pd3: false,
+            sd3: false,
+            pr3: false,
+            cr3: false,
+            pd6: false,
+            sd6: false,
+            pr6: false,
+            cr6: false,
+            pd12: false,
+            sd12: false,
+            pr12: false,
+            cr12: false,
+        } as IResponseCriteria;
         const newFollowUp = {
             id: 'followUp_' + this.props.patientId + '_' + now.getTime(),
             therapyRecommendation: therapyRecommendation,
@@ -245,6 +379,11 @@ export default class FollowUpTable extends React.Component<
             author: getAuthor(),
             comment: '',
             therapyRecommendationRealized: false,
+            sideEffect: false,
+            response: emptyResponseCriteria,
+            // responseMonthThree: emptyResponseCriteria,
+            // responseMonthSix: emptyResponseCriteria,
+            // responseMonthTwelve: emptyResponseCriteria
         } as IFollowUp;
         newFollowUps.push(newFollowUp);
         this.setState({ followUps: newFollowUps });
@@ -277,6 +416,30 @@ export default class FollowUpTable extends React.Component<
         console.group('Test');
         console.log(this.props);
         console.groupEnd();
+    }
+
+    private getTreatmentResponseCheckbox(
+        followUp: IFollowUp,
+        criteria: IResponseCriteria,
+        attribute: keyof IResponseCriteria
+    ) {
+        return (
+            <LabeledCheckbox
+                checked={criteria[attribute]}
+                onChange={() => {
+                    const newCriteria = { ...criteria };
+                    newCriteria[attribute] = !criteria[attribute];
+                    const newFollowUps = this.state.followUps.slice();
+                    newFollowUps.find(
+                        x => x.id === followUp.id
+                    )!.response = newCriteria;
+                    this.setState({ followUps: newFollowUps });
+                }}
+                labelProps={{ style: { marginRight: 10 } }}
+            >
+                {/* <span style={{ marginTop: '-2px' }}>{label}</span> */}
+            </LabeledCheckbox>
+        );
     }
 
     render() {

--- a/src/pages/patientView/therapyRecommendation/FollowUpTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/FollowUpTable.tsx
@@ -34,6 +34,7 @@ import Select from 'react-select';
 import { VariantAnnotation, MyVariantInfo } from 'genome-nexus-ts-api-client';
 import FollowUpForm from './form/FollowUpForm';
 import AppConfig from 'appConfig';
+import { Collapse } from 'react-collapse';
 
 export type IFollowUpProps = {
     patientId: string;
@@ -151,6 +152,9 @@ export default class FollowUpTable extends React.Component<
                     >
                         <span style={{ marginTop: '-2px' }}>Realized</span>
                     </LabeledCheckbox>
+                    <Collapse isOpened={followUp.therapyRecommendationRealized}>
+                        <span>Tumor response criteria</span>
+                    </Collapse>
                     <textarea
                         title="Comments"
                         rows={4}

--- a/src/pages/patientView/therapyRecommendation/MtbTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTable.tsx
@@ -292,6 +292,7 @@ export default class MtbTable extends React.Component<IMtbProps, IMtbState> {
                     cnaOncoKbData={this.props.cnaOncoKbData}
                     pubMedCache={this.props.pubMedCache}
                     isDisabled={this.isDisabled(mtb)}
+                    showButtons={true}
                 />
             ),
             width: this.columnWidths[ColumnKey.THERAPYRECOMMENDATIONS],

--- a/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
@@ -66,6 +66,8 @@ export type ITherapyRecommendationProps = {
     cnaOncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
     pubMedCache?: PubMedCache;
     isDisabled: boolean;
+    showButtons: boolean;
+    columnVisibility?: { [columnId: string]: boolean };
 };
 
 export type ITherapyRecommendationState = {
@@ -662,54 +664,62 @@ export default class MtbTherapyRecommendationTable extends React.Component<
     render() {
         return (
             <div>
-                <p className={styles.edit}>
-                    <Button
-                        type="button"
-                        className={'btn btn-default ' + styles.addButton}
-                        disabled={this.props.isDisabled}
-                        onClick={() => this.openAddForm()}
-                    >
-                        <i
-                            className={`fa fa-plus ${styles.marginLeft}`}
-                            aria-hidden="true"
-                        ></i>{' '}
-                        Add
-                    </Button>
-                    <If condition={this.props.oncoKbAvailable}>
-                        <Then>
+                <If condition={this.props.showButtons}>
+                    <Then>
+                        <p className={styles.edit}>
                             <Button
                                 type="button"
                                 className={
-                                    'btn btn-default ' + styles.addOncoKbButton
+                                    'btn btn-default ' + styles.addButton
                                 }
                                 disabled={this.props.isDisabled}
-                                onClick={() => this.openAddOncoKbForm()}
+                                onClick={() => this.openAddForm()}
                             >
                                 <i
                                     className={`fa fa-plus ${styles.marginLeft}`}
                                     aria-hidden="true"
                                 ></i>{' '}
-                                Add from OncoKB
+                                Add
                             </Button>
-                        </Then>
-                        <Else>
-                            <Button
-                                type="button"
-                                className={
-                                    'btn btn-default ' + styles.addOncoKbButton
-                                }
-                                disabled={true}
-                            >
-                                <i
-                                    className={`fa fa-exclamation-triangle ${styles.marginLeft}`}
-                                    aria-hidden="true"
-                                ></i>{' '}
-                                OncoKB unavailable
-                            </Button>
-                        </Else>
-                    </If>
-                    {/* <Button type="button" className={"btn btn-default " + styles.testButton} onClick={() => this.test()}>Test (Update)</Button> */}
-                </p>
+                            <If condition={this.props.oncoKbAvailable}>
+                                <Then>
+                                    <Button
+                                        type="button"
+                                        className={
+                                            'btn btn-default ' +
+                                            styles.addOncoKbButton
+                                        }
+                                        disabled={this.props.isDisabled}
+                                        onClick={() => this.openAddOncoKbForm()}
+                                    >
+                                        <i
+                                            className={`fa fa-plus ${styles.marginLeft}`}
+                                            aria-hidden="true"
+                                        ></i>{' '}
+                                        Add from OncoKB
+                                    </Button>
+                                </Then>
+                                <Else>
+                                    <Button
+                                        type="button"
+                                        className={
+                                            'btn btn-default ' +
+                                            styles.addOncoKbButton
+                                        }
+                                        disabled={true}
+                                    >
+                                        <i
+                                            className={`fa fa-exclamation-triangle ${styles.marginLeft}`}
+                                            aria-hidden="true"
+                                        ></i>{' '}
+                                        OncoKB unavailable
+                                    </Button>
+                                </Else>
+                            </If>
+                            {/* <Button type="button" className={"btn btn-default " + styles.testButton} onClick={() => this.test()}>Test (Update)</Button> */}
+                        </p>
+                    </Then>
+                </If>
                 {this.selectedTherapyRecommendation && (
                     <TherapyRecommendationForm
                         show={!!this.selectedTherapyRecommendation}
@@ -765,8 +775,9 @@ export default class MtbTherapyRecommendationTable extends React.Component<
                     data={this.props.therapyRecommendations}
                     columns={this._columns}
                     showCopyDownload={false}
-                    // showFilter={false}
+                    showFilter={false}
                     showColumnVisibility={false}
+                    columnVisibility={this.props.columnVisibility} //{{"Edit": false, "Comment": true}}
                 />
                 {/* <SimpleCopyDownloadControls
                     downloadData={() =>

--- a/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
@@ -56,9 +56,9 @@ export type ITherapyRecommendationProps = {
     oncoKbAvailable: boolean;
     therapyRecommendations: ITherapyRecommendation[];
     containerWidth: number;
-    onDelete: (therapyRecommendation: ITherapyRecommendation) => boolean;
-    onAddOrEdit: (therapyRecommendation?: ITherapyRecommendation) => boolean;
-    onReposition: (
+    onDelete?: (therapyRecommendation: ITherapyRecommendation) => boolean;
+    onAddOrEdit?: (therapyRecommendation?: ITherapyRecommendation) => boolean;
+    onReposition?: (
         therapyRecommendation: ITherapyRecommendation,
         newIndex: number
     ) => boolean;
@@ -139,6 +139,7 @@ export default class MtbTherapyRecommendationTable extends React.Component<
                                 this.findIndex(therapyRecommendation) <= 0
                             }
                             onClick={() =>
+                                this.props.onReposition &&
                                 this.props.onReposition(
                                     therapyRecommendation,
                                     this.findIndex(therapyRecommendation) - 1
@@ -161,6 +162,7 @@ export default class MtbTherapyRecommendationTable extends React.Component<
                                     this.props.therapyRecommendations.length - 1
                             }
                             onClick={() =>
+                                this.props.onReposition &&
                                 this.props.onReposition(
                                     therapyRecommendation,
                                     this.findIndex(therapyRecommendation) + 1
@@ -513,7 +515,7 @@ export default class MtbTherapyRecommendationTable extends React.Component<
     }
 
     public openDeleteForm(therapyRecommendation: ITherapyRecommendation) {
-        if (this.props.onDelete(therapyRecommendation))
+        if (this.props.onDelete && this.props.onDelete(therapyRecommendation))
             this.updateTherapyRecommendationTable();
     }
 
@@ -568,14 +570,15 @@ export default class MtbTherapyRecommendationTable extends React.Component<
             isTherapyRecommendationEmpty(newTherapyRecommendation)
         ) {
             if (this.backupTherapyRecommendation) {
-                this.props.onAddOrEdit(undefined);
+                this.props.onAddOrEdit && this.props.onAddOrEdit(undefined);
                 this.backupTherapyRecommendation = undefined;
             }
         } else {
             newTherapyRecommendation = setAuthorInTherapyRecommendation(
                 newTherapyRecommendation
             );
-            this.props.onAddOrEdit(newTherapyRecommendation);
+            this.props.onAddOrEdit &&
+                this.props.onAddOrEdit(newTherapyRecommendation);
         }
         this.showOncoKBForm = false;
         this.updateTherapyRecommendationTable();

--- a/src/pages/patientView/therapyRecommendation/form/FollowUpForm.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/FollowUpForm.tsx
@@ -58,27 +58,36 @@ export default class FollowUpForm extends React.Component<
                         <div className="form-group">
                             <h5>Select therapy recommendation:</h5>
                             <Select
-                                options={this.props.mtbs.map(mtb => ({
-                                    label: 'MTB' + ' ' + mtb.date,
-                                    options: mtb.therapyRecommendations.map(
-                                        (
-                                            therapyRecommendation,
-                                            therapyRecommendationIndex
-                                        ) => ({
-                                            label: therapyRecommendation
-                                                .treatments.length
-                                                ? therapyRecommendation.treatments.map(
-                                                      treatment =>
-                                                          treatment.name
-                                                  )
-                                                : 'No treatment specified',
-                                            value: {
-                                                mtb,
+                                options={this.props.mtbs.map(mtb => {
+                                    let d = new Date(mtb.date);
+                                    let dateString =
+                                        ('0' + d.getDate()).slice(-2) +
+                                        '.' +
+                                        ('0' + (d.getMonth() + 1)).slice(-2) +
+                                        '.' +
+                                        d.getFullYear();
+                                    return {
+                                        label: 'MTB' + ' ' + dateString,
+                                        options: mtb.therapyRecommendations.map(
+                                            (
                                                 therapyRecommendation,
-                                            },
-                                        })
-                                    ),
-                                }))}
+                                                therapyRecommendationIndex
+                                            ) => ({
+                                                label: therapyRecommendation
+                                                    .treatments.length
+                                                    ? therapyRecommendation.treatments.map(
+                                                          treatment =>
+                                                              treatment.name
+                                                      )
+                                                    : 'No treatment specified',
+                                                value: {
+                                                    mtb,
+                                                    therapyRecommendation,
+                                                },
+                                            })
+                                        ),
+                                    };
+                                })}
                                 name="therapyRecommendationSelect"
                                 className="basic-select"
                                 classNamePrefix="select"

--- a/src/pages/patientView/therapyRecommendation/form/FollowUpForm.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/FollowUpForm.tsx
@@ -4,6 +4,7 @@ import { Modal, Button } from 'react-bootstrap';
 import {
     ITherapyRecommendation,
     IMtb,
+    MtbState,
 } from 'shared/model/TherapyRecommendation';
 import Select from 'react-select';
 
@@ -58,36 +59,40 @@ export default class FollowUpForm extends React.Component<
                         <div className="form-group">
                             <h5>Select therapy recommendation:</h5>
                             <Select
-                                options={this.props.mtbs.map(mtb => {
-                                    let d = new Date(mtb.date);
-                                    let dateString =
-                                        ('0' + d.getDate()).slice(-2) +
-                                        '.' +
-                                        ('0' + (d.getMonth() + 1)).slice(-2) +
-                                        '.' +
-                                        d.getFullYear();
-                                    return {
-                                        label: 'MTB' + ' ' + dateString,
-                                        options: mtb.therapyRecommendations.map(
-                                            (
-                                                therapyRecommendation,
-                                                therapyRecommendationIndex
-                                            ) => ({
-                                                label: therapyRecommendation
-                                                    .treatments.length
-                                                    ? therapyRecommendation.treatments.map(
-                                                          treatment =>
-                                                              treatment.name
-                                                      )
-                                                    : 'No treatment specified',
-                                                value: {
-                                                    mtb,
+                                options={this.props.mtbs
+                                    // .filter(mtb => mtb.mtbState.valueOf() == "FINAL" ? true : false)
+                                    .map(mtb => {
+                                        let d = new Date(mtb.date);
+                                        let dateString =
+                                            ('0' + d.getDate()).slice(-2) +
+                                            '.' +
+                                            ('0' + (d.getMonth() + 1)).slice(
+                                                -2
+                                            ) +
+                                            '.' +
+                                            d.getFullYear();
+                                        return {
+                                            label: 'MTB' + ' ' + dateString,
+                                            options: mtb.therapyRecommendations.map(
+                                                (
                                                     therapyRecommendation,
-                                                },
-                                            })
-                                        ),
-                                    };
-                                })}
+                                                    therapyRecommendationIndex
+                                                ) => ({
+                                                    label: therapyRecommendation
+                                                        .treatments.length
+                                                        ? therapyRecommendation.treatments.map(
+                                                              treatment =>
+                                                                  treatment.name
+                                                          )
+                                                        : 'No treatment specified',
+                                                    value: {
+                                                        mtb,
+                                                        therapyRecommendation,
+                                                    },
+                                                })
+                                            ),
+                                        };
+                                    })}
                                 name="therapyRecommendationSelect"
                                 className="basic-select"
                                 classNamePrefix="select"

--- a/src/pages/patientView/therapyRecommendation/form/FollowUpForm.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/FollowUpForm.tsx
@@ -24,13 +24,6 @@ export default class FollowUpForm extends React.Component<
     IFollowUpFormProps,
     {}
 > {
-    private indicationSort(a: string, b: string): number {
-        // Increase ascii code of parentheses to put these entries after text in the sort order
-        a = a.trim().replace('(', '{');
-        b = b.trim().replace('(', '{');
-        return a < b ? -1 : 1;
-    }
-
     public render() {
         let selectedTherapyRecommendation: ITherapyRecommendation;
         const groupStyles = {
@@ -72,9 +65,13 @@ export default class FollowUpForm extends React.Component<
                                             therapyRecommendation,
                                             therapyRecommendationIndex
                                         ) => ({
-                                            label: therapyRecommendation.treatments.map(
-                                                treatment => treatment.name
-                                            ),
+                                            label: therapyRecommendation
+                                                .treatments.length
+                                                ? therapyRecommendation.treatments.map(
+                                                      treatment =>
+                                                          treatment.name
+                                                  )
+                                                : 'No treatment specified',
                                             value: {
                                                 mtb,
                                                 therapyRecommendation,

--- a/src/pages/patientView/therapyRecommendation/form/FollowUpForm.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/FollowUpForm.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Modal, Button } from 'react-bootstrap';
+import {
+    ITherapyRecommendation,
+    IMtb,
+} from 'shared/model/TherapyRecommendation';
+import Select from 'react-select';
+
+interface IFollowUpFormProps {
+    show: boolean;
+    patientID: string;
+    title: string;
+    userEmailAddress: string;
+    mtbs: IMtb[];
+    onHide: (
+        newTherapyRecommendation?:
+            | ITherapyRecommendation
+            | ITherapyRecommendation[]
+    ) => void;
+}
+
+export default class FollowUpForm extends React.Component<
+    IFollowUpFormProps,
+    {}
+> {
+    private indicationSort(a: string, b: string): number {
+        // Increase ascii code of parentheses to put these entries after text in the sort order
+        a = a.trim().replace('(', '{');
+        b = b.trim().replace('(', '{');
+        return a < b ? -1 : 1;
+    }
+
+    public render() {
+        let selectedTherapyRecommendation: ITherapyRecommendation;
+        const groupStyles = {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            fontSize: 18,
+        };
+        const groupBadgeStyles = {
+            backgroundColor: '#EBECF0',
+            borderRadius: '2em',
+            color: '#172B4D',
+            display: 'inline-block',
+            fontSize: 12,
+            lineHeight: '1',
+            minWidth: 1,
+            padding: '0.16666666666667em 0.5em',
+        };
+        return (
+            <Modal
+                show={this.props.show}
+                onHide={() => {
+                    this.props.onHide(undefined);
+                }}
+                backdrop={'static'}
+            >
+                <Modal.Header closeButton>
+                    <Modal.Title>{this.props.title}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <form className="form">
+                        <div className="form-group">
+                            <h5>Select therapy recommendation:</h5>
+                            <Select
+                                options={this.props.mtbs.map(mtb => ({
+                                    label: 'MTB' + ' ' + mtb.date,
+                                    options: mtb.therapyRecommendations.map(
+                                        (
+                                            therapyRecommendation,
+                                            therapyRecommendationIndex
+                                        ) => ({
+                                            label: therapyRecommendation.treatments.map(
+                                                treatment => treatment.name
+                                            ),
+                                            value: {
+                                                mtb,
+                                                therapyRecommendation,
+                                            },
+                                        })
+                                    ),
+                                }))}
+                                name="therapyRecommendationSelect"
+                                className="basic-select"
+                                classNamePrefix="select"
+                                onChange={(selectedOption: {
+                                    label: string;
+                                    value: {
+                                        mtb: IMtb;
+                                        therapyRecommendation: ITherapyRecommendation;
+                                    };
+                                }) => {
+                                    let therapyRecommendation =
+                                        selectedOption.value
+                                            .therapyRecommendation;
+                                    console.log(selectedOption);
+                                    selectedTherapyRecommendation = therapyRecommendation;
+                                }}
+                                formatGroupLabel={(data: any) => (
+                                    <div
+                                        style={groupStyles}
+                                        // onClick={(e: any) => {
+                                        //     e.stopPropagation();
+                                        //     e.preventDefault();
+                                        //     console.log('Group heading clicked', data);
+                                        // }}
+                                    >
+                                        <span>{data.label}</span>
+                                        <span style={groupBadgeStyles}>
+                                            {data.options.length}
+                                        </span>
+                                    </div>
+                                )}
+                            />
+                        </div>
+                    </form>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button
+                        type="button"
+                        bsStyle="default"
+                        onClick={() => {
+                            this.props.onHide(undefined);
+                        }}
+                    >
+                        Dismiss
+                    </Button>
+                    <Button
+                        type="button"
+                        bsStyle="primary"
+                        onClick={() => {
+                            this.props.onHide(selectedTherapyRecommendation);
+                        }}
+                    >
+                        Select therapy recommendation
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}

--- a/src/pages/patientView/therapyRecommendation/style/therapyRecommendation.module.scss
+++ b/src/pages/patientView/therapyRecommendation/style/therapyRecommendation.module.scss
@@ -138,6 +138,17 @@
         background: #73ad21 !important;
     }
 
+    .addFollowUpButton {
+        float: left;
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+        margin-top: 10px;
+        width: 180px;
+        color: white !important;
+        background: #73ad21 !important;
+    }
+
     .addOncoKbButton {
         float: left;
         display: block;

--- a/src/pages/patientView/therapyRecommendation/style/therapyRecommendation.module.scss.d.ts
+++ b/src/pages/patientView/therapyRecommendation/style/therapyRecommendation.module.scss.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly "addButton": string;
+  readonly "addFollowUpButton": string;
   readonly "addMtbButton": string;
   readonly "addOncoKbButton": string;
   readonly "alterationUl": string;

--- a/src/shared/api/TherapyRecommendationAPI.ts
+++ b/src/shared/api/TherapyRecommendationAPI.ts
@@ -83,9 +83,7 @@ export async function fetchFollowupUsingGET(url: string) {
                             therapyRecommendationRealized:
                                 followup.therapyRecommendationRealized,
                             sideEffect: followup.sideEffect,
-                            responseMonthThree: followup.responseMonthThree,
-                            responseMonthSix: followup.responseMonthSix,
-                            responseMonthTwelve: followup.responseMonthTwelve,
+                            response: followup.response,
                             comment: followup.comment,
                         } as IFollowUp)
                 );

--- a/src/shared/api/TherapyRecommendationAPI.ts
+++ b/src/shared/api/TherapyRecommendationAPI.ts
@@ -1,4 +1,8 @@
-import { IMtb, IDeletions } from 'shared/model/TherapyRecommendation';
+import {
+    IMtb,
+    IDeletions,
+    IFollowUp,
+} from 'shared/model/TherapyRecommendation';
 import * as request from 'superagent';
 
 export function flattenArray(x: Array<any>): Array<any> {
@@ -58,6 +62,52 @@ export async function fetchMtbsUsingGET(url: string) {
         });
 }
 
+export async function fetchFollowupUsingGET(url: string) {
+    console.log('### FOLLOWUP ### Calling GET: ' + url);
+    return request
+        .get(url)
+        .then(res => {
+            if (res.ok) {
+                console.group('### FOLLOWUP ### Success GETting ' + url);
+                console.log(JSON.parse(res.text));
+                console.groupEnd();
+                const response = JSON.parse(res.text);
+                return response.followups.map(
+                    (followup: any) =>
+                        ({
+                            id: followup.id,
+                            therapyRecommendation:
+                                followup.therapyRecommendation,
+                            date: followup.date,
+                            author: followup.author,
+                            therapyRecommendationRealized:
+                                followup.therapyRecommendationRealized,
+                            sideEffect: followup.sideEffect,
+                            responseMonthThree: followup.responseMonthThree,
+                            responseMonthSix: followup.responseMonthSix,
+                            responseMonthTwelve: followup.responseMonthTwelve,
+                            comment: followup.comment,
+                        } as IFollowUp)
+                );
+            } else {
+                console.group(
+                    '### FOLLOWUP ### ERROR res not ok GETting ' + url
+                );
+                console.log(JSON.parse(res.text));
+                console.groupEnd();
+
+                return [] as IFollowUp[];
+            }
+        })
+        .catch(err => {
+            console.group('### FOLLOWUP ### ERROR catched GETting ' + url);
+            console.log(err);
+            console.groupEnd();
+
+            return [] as IFollowUp[];
+        });
+}
+
 export async function updateMtbUsingPUT(id: string, url: string, mtbs: IMtb[]) {
     mtbs.forEach(
         mtb =>
@@ -93,6 +143,41 @@ export async function updateMtbUsingPUT(id: string, url: string, mtbs: IMtb[]) {
         });
 }
 
+export async function updateFollowupUsingPUT(
+    id: string,
+    url: string,
+    followups: IFollowUp[]
+) {
+    console.log('### FOLLOWUP ### Calling PUT: ' + url);
+    return request
+        .put(url)
+        .set('Content-Type', 'application/json')
+        .send(
+            JSON.stringify({
+                id: id,
+                followups: flattenArray(followups),
+            })
+        )
+        .then(res => {
+            if (res.ok) {
+                console.group('### FOLLOWUP ### Success PUTting ' + url);
+                console.log(JSON.parse(res.text));
+                console.groupEnd();
+            } else {
+                console.group(
+                    '### FOLLOWUP ### ERROR res not ok PUTting ' + url
+                );
+                console.log(JSON.parse(res.text));
+                console.groupEnd();
+            }
+        })
+        .catch(err => {
+            console.group('### FOLLOWUP ### ERROR catched PUTting ' + url);
+            console.log(err);
+            console.groupEnd();
+        });
+}
+
 export async function deleteMtbUsingDELETE(
     id: string,
     url: string,
@@ -118,6 +203,38 @@ export async function deleteMtbUsingDELETE(
         })
         .catch(err => {
             console.group('### MTB ### ERROR catched DELETEing ' + url);
+            console.log(err);
+            console.groupEnd();
+        });
+}
+
+export async function deleteFollowupUsingDELETE(
+    id: string,
+    url: string,
+    deletions: IDeletions
+) {
+    console.log('### FOLLOWUP ### Calling DELETE: ' + url);
+    return request
+        .delete(url)
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify(deletions))
+        .then(res => {
+            if (res.ok) {
+                deletions.mtb = [];
+                deletions.therapyRecommendation = [];
+                console.group('### FOLLOWUP ### Success DELETEing ' + url);
+                console.log(JSON.parse(res.text));
+                console.groupEnd();
+            } else {
+                console.group(
+                    '### FOLLOWUP ### ERROR res not ok DELETEing ' + url
+                );
+                console.log(JSON.parse(res.text));
+                console.groupEnd();
+            }
+        })
+        .catch(err => {
+            console.group('### FOLLOWUP ### ERROR catched DELETEing ' + url);
             console.log(err);
             console.groupEnd();
         });

--- a/src/shared/model/TherapyRecommendation.ts
+++ b/src/shared/model/TherapyRecommendation.ts
@@ -22,6 +22,26 @@ export interface IRecommender {
     email?: string;
 }
 
+export interface IResponseCriteria {
+    cr: boolean;
+    pr: boolean;
+    sd: boolean;
+    pd: boolean;
+}
+
+export interface IFollowUp {
+    id: string;
+    therapyRecommendation: ITherapyRecommendation;
+    date: string;
+    author: string;
+    therapyRecommendationRealized: boolean;
+    sideEffect?: boolean;
+    responseMonthThree?: IResponseCriteria;
+    responseMonthSix?: IResponseCriteria;
+    responseMonthTwelve?: IResponseCriteria;
+    comment: string;
+}
+
 export interface IMtb {
     id: string;
     therapyRecommendations: ITherapyRecommendation[];

--- a/src/shared/model/TherapyRecommendation.ts
+++ b/src/shared/model/TherapyRecommendation.ts
@@ -109,4 +109,5 @@ export interface IGeneticAlteration {
 export interface IDeletions {
     mtb: string[];
     therapyRecommendation: string[];
+    followUp: string[];
 }

--- a/src/shared/model/TherapyRecommendation.ts
+++ b/src/shared/model/TherapyRecommendation.ts
@@ -23,10 +23,18 @@ export interface IRecommender {
 }
 
 export interface IResponseCriteria {
-    cr: boolean;
-    pr: boolean;
-    sd: boolean;
-    pd: boolean;
+    cr3: boolean;
+    pr3: boolean;
+    sd3: boolean;
+    pd3: boolean;
+    cr6: boolean;
+    pr6: boolean;
+    sd6: boolean;
+    pd6: boolean;
+    cr12: boolean;
+    pr12: boolean;
+    sd12: boolean;
+    pd12: boolean;
 }
 
 export interface IFollowUp {
@@ -35,10 +43,8 @@ export interface IFollowUp {
     date: string;
     author: string;
     therapyRecommendationRealized: boolean;
-    sideEffect?: boolean;
-    responseMonthThree?: IResponseCriteria;
-    responseMonthSix?: IResponseCriteria;
-    responseMonthTwelve?: IResponseCriteria;
+    sideEffect: boolean;
+    response: IResponseCriteria;
     comment: string;
 }
 


### PR DESCRIPTION
PR for follow-up tab prototype.

Known todos/caveats:
- implementing communication with FHIR server
- disable/hide-able form elements for follow-up data elements (side effects, response criteria)
- currently only fetched therapy recommendations can be selected as there is no communication between the tabs