### PR TITLE
Visualize LoH mutations

### DIFF
--- a/src/shared/components/mutationTable/MutationTable.tsx
+++ b/src/shared/components/mutationTable/MutationTable.tsx
@@ -609,7 +609,7 @@ export default class MutationTable<
                 filterString: string,
                 filterStringUpper: string
             ) => defaultFilter(d, 'mutationStatus', filterStringUpper),
-            visible: false,
+            visible: true,
         };
 
         this._columns[MutationTableColumnType.VALIDATION_STATUS] = {

--- a/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.tsx
+++ b/src/shared/components/mutationTable/column/MutationStatusColumnFormatter.tsx
@@ -37,6 +37,9 @@ export default class MutationStatusColumnFormatter {
             } else if (value.toLowerCase().indexOf('germline') > -1) {
                 content = <span className={styles.germline}>G</span>;
                 needTooltip = true;
+            } else if (value.toLowerCase().indexOf('loh') > -1) {
+                content = <span className={styles.loh}>L</span>;
+                needTooltip = true;
             } else {
                 content = <span className={styles.unknown}>{value}</span>;
             }

--- a/src/shared/components/mutationTable/column/mutationStatus.module.scss
+++ b/src/shared/components/mutationTable/column/mutationStatus.module.scss
@@ -16,6 +16,15 @@
     font-size: small;
 }
 
+.loh {
+    background: #ffcccc;
+    color: #000000;
+    padding-left: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: small;
+}
+
 .unknown {
     color: #9d9d9d;
     font-size: xx-small;

--- a/src/shared/components/mutationTable/column/mutationStatus.module.scss.d.ts
+++ b/src/shared/components/mutationTable/column/mutationStatus.module.scss.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly "germline": string;
+  readonly "loh": string;
   readonly "somatic": string;
   readonly "unknown": string;
 };


### PR DESCRIPTION
This adds a style for displaying LoH mutations in the frontend like this:
![image](https://user-images.githubusercontent.com/20756025/124468504-78b82180-dd99-11eb-85b6-9d709e4d75e2.png)
S is somatic
G is germline
L is LoH

There is also a tooltip available when you hover over the entry.