### PR TITLE
Use localStorage instead of sessionStorage in CancerDrugs

### DIFF
--- a/packages/react-mutation-mapper/src/component/oncokb/OncoKbTreatmentTable.tsx
+++ b/packages/react-mutation-mapper/src/component/oncokb/OncoKbTreatmentTable.tsx
@@ -13,8 +13,8 @@ import mainStyles from './main.module.scss';
 import './oncoKbTreatmentTable.scss';
 import request from 'superagent';
 
-let cancerdrugsUrl = sessionStorage.getItem('cancerdrugsUrl') || '';
-let cancerdrugsJsonUrl = sessionStorage.getItem('cancerdrugsJsonUrl') || '';
+let cancerdrugsUrl = localStorage.getItem('cancerdrugsUrl') || '';
+let cancerdrugsJsonUrl = localStorage.getItem('cancerdrugsJsonUrl') || '';
 
 type OncoKbTreatmentTableProps = {
     variant: string;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -123,8 +123,8 @@ export function setServerConfig(serverConfig: { [key: string]: any }) {
         config.cancerdrugsJsonUrl = frontendOverride.cancerdrugsJsonUrl;
     }
 
-    sessionStorage.setItem('cancerdrugsUrl', AppConfig.cancerdrugsUrl || '');
-    sessionStorage.setItem(
+    localStorage.setItem('cancerdrugsUrl', AppConfig.cancerdrugsUrl || '');
+    localStorage.setItem(
         'cancerdrugsJsonUrl',
         AppConfig.cancerdrugsJsonUrl || ''
     );


### PR DESCRIPTION
Currently we use "sessionStorage" for setting the CancerDrugs URL. If we switch to "localStorage" this URL will be set when accessing cBioPortal and be immediately available for the patient view that opens in a new tab. sessionStorage however is limited to tabs, so CancerDrugs works only if you reload the page once.