### PR TITLE
Support custom attributes in patient header

### DIFF
--- a/attributes.json
+++ b/attributes.json
@@ -1,0 +1,6 @@
+{
+    "PATIENT_DISPLAY_NAME": {
+        "primary": true,
+        "order": 0
+    }
+}

--- a/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
+++ b/src/pages/patientView/clinicalInformation/lib/clinicalAttributesUtil.js
@@ -201,8 +201,49 @@ function getSpanElements(clinicalData) {
     return getSpanElementsFromCleanData(cleanAndDerive(clinicalData));
 }
 
+function parseIt(json) {
+    return JSON.parse(json, function(key, value) {
+        if (
+            typeof value === 'string' &&
+            value.startsWith('/Function(') &&
+            value.endsWith(')/')
+        ) {
+            value = value.substring(10, value.length - 2);
+            var string = value.slice(
+                value.indexOf('(') + 1,
+                value.indexOf(')')
+            );
+            if (/\S+/g.test(string)) {
+                return new Function(
+                    string,
+                    value.slice(value.indexOf('{') + 1, value.lastIndexOf('}'))
+                );
+            } else {
+                return new Function(
+                    value.slice(value.indexOf('{') + 1, value.lastIndexOf('}'))
+                );
+            }
+        }
+        if (
+            typeof value === 'string' &&
+            value.startsWith('/String(') &&
+            value.endsWith(')/')
+        ) {
+            value = value.substring(8, value.length - 2);
+        }
+        return value;
+    });
+}
+
 function getSpanElementsFromCleanData(clinicalAttributesCleanDerived) {
     const config = styleConsts.config;
+    try {
+        fetch('/attributes.json').then(res =>
+            res.text().then(t => Object.assign(config, parseIt(t)))
+        );
+    } catch (error) {
+        console.log(error);
+    }
     const sortedKeys = Object.keys(clinicalAttributesCleanDerived)
         .sort((a, b) => {
             return styleConsts.compare(a, b, config);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -197,6 +197,10 @@ var config = {
                 from: './src/globalStyles/prefixed-bootstrap.min.css.map',
                 to: 'reactapp/prefixed-bootstrap.min.css.map',
             },
+            {
+                from: './attributes.json',
+                to: 'attributes.json',
+            },
         ]), // destination is relative to dist directory
         new TypedCssModulesPlugin({
             globPattern: 'src/**/*.module.scss',


### PR DESCRIPTION
This allows adding (and formatting) additional attributes in the patient header. The included example sets the Patient name as a primary attribute, resulting in a removal of the parenthesis around the name. 
Adding additional attributes is also possible. Those can also contain formatting options as a serialized JavaScript function like so:
```
{
    "ECOG_STATE": {
        "primary": true,
        "order": 5,
        "formatter": "/Function((t) => {return `ECOG: ${t}`;})/"
    }
}
``` 
(This is the region that is affected by this change:)
<img width="885" alt="Screenshot 2021-12-13 at 11 05 07" src="https://user-images.githubusercontent.com/20756025/145805162-b69f26b7-ffcd-45f7-95d9-bca980c8ee9f.png">

