### PR TITLE
Evidence level extension

### DIFF
--- a/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
@@ -297,7 +297,8 @@ export default class MtbTherapyRecommendationTable extends React.Component<
                 <div>
                     <span style={{ marginRight: 5 }}>
                         Level{' '}
-                        <b>{therapyRecommendation.evidenceLevel || 'NA'}</b>
+                        <b>{therapyRecommendation.evidenceLevel || 'NA'}</b>{' '}
+                        {therapyRecommendation.evidenceLevelExtension || ''}
                     </span>
                     <If condition={therapyRecommendation.evidenceLevel}>
                         <DefaultTooltip

--- a/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
@@ -299,6 +299,11 @@ export default class MtbTherapyRecommendationTable extends React.Component<
                         Level{' '}
                         <b>{therapyRecommendation.evidenceLevel || 'NA'}</b>{' '}
                         {therapyRecommendation.evidenceLevelExtension || ''}
+                        {therapyRecommendation.evidenceLevelM3Text
+                            ? ' (' +
+                              therapyRecommendation.evidenceLevelM3Text +
+                              ')'
+                            : ''}
                     </span>
                     <If condition={therapyRecommendation.evidenceLevel}>
                         <DefaultTooltip

--- a/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
+++ b/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
@@ -40,6 +40,7 @@ export function getNewTherapyRecommendation(
         reasoning: {},
         evidenceLevel: EvidenceLevel.NA,
         evidenceLevelExtension: EvidenceLevelExtension.NA,
+        evidenceLevelM3Text: '',
         author: getAuthor(),
         references: [],
         treatments: [],
@@ -267,6 +268,38 @@ export function getEvidenceLevelDesc() {
                 Assoziation des Biomarkers mit der Wirksamkeit der Medikation
                 nahe, welche bisher{' '}
                 <b>nicht durch (pr&auml;)klinische Daten </b>gest&uuml;tzt wird.
+            </span>
+        ),
+        is: (
+            <span>
+                <i>In situ</i>-Daten aus Untersuchungen an Patientenmaterial
+                (z.B. IHC, FISH) unterstützen den Evidenzgrad. Die
+                unterstützende Methode kann in Klammern zusätzlich angegeben
+                werden, z.B. Evidenzgrad 3 is (IHC).
+            </span>
+        ),
+        iv: (
+            <span>
+                <i>In vitro</i>-Daten/ <i>in vivo</i>-Modelle (z.B. PDX-Modelle)
+                derselben Tumorentität unterstützen den Evidenzgrad. Die
+                unterstützende Methode kann in Klammern angegeben werden, z.B.
+                Evidenzgrad 2 iv (PDX).
+            </span>
+        ),
+        'Z(FDA)': (
+            <span>
+                Zusatzhinweis für Zulassungsstatus: FDA-Zulassung liegt vor.
+            </span>
+        ),
+        'Z(EMA)': (
+            <span>
+                Zusatzhinweis für Zulassungsstatus: EMA-Zulassung liegt vor.
+            </span>
+        ),
+        R: (
+            <span>
+                Verweis, dass es sich hierbei um einen Resistenzmarker für eine
+                bestimmte Therapie handelt.
             </span>
         ),
     };

--- a/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
+++ b/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
@@ -2,6 +2,7 @@ import {
     ITherapyRecommendation,
     EvidenceLevel,
     IReference,
+    EvidenceLevelExtension,
 } from 'shared/model/TherapyRecommendation';
 import _ from 'lodash';
 import request from 'superagent';
@@ -38,6 +39,7 @@ export function getNewTherapyRecommendation(
         comment: [],
         reasoning: {},
         evidenceLevel: EvidenceLevel.NA,
+        evidenceLevelExtension: EvidenceLevelExtension.NA,
         author: getAuthor(),
         references: [],
         treatments: [],

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationForm.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationForm.tsx
@@ -122,6 +122,9 @@ export default class TherapyRecommendationForm extends React.Component<
                                 onChangeExtension={evidenceLevelExtension =>
                                     (therapyRecommendation.evidenceLevelExtension = evidenceLevelExtension)
                                 }
+                                onChangeM3Text={text =>
+                                    (therapyRecommendation.evidenceLevelM3Text = text)
+                                }
                             />
                         </div>
 

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationForm.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationForm.tsx
@@ -119,6 +119,9 @@ export default class TherapyRecommendationForm extends React.Component<
                                 onChange={evidenceLevel =>
                                     (therapyRecommendation.evidenceLevel = evidenceLevel)
                                 }
+                                onChangeExtension={evidenceLevelExtension =>
+                                    (therapyRecommendation.evidenceLevelExtension = evidenceLevelExtension)
+                                }
                             />
                         </div>
 

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
     ITherapyRecommendation,
     EvidenceLevel,
+    EvidenceLevelExtension,
 } from 'shared/model/TherapyRecommendation';
 import Select from 'react-select';
 import _ from 'lodash';
@@ -12,18 +13,56 @@ import {
     DefaultTooltip,
     placeArrowBottomLeft,
 } from 'cbioportal-frontend-commons';
+import { Checkbox, Col, Row } from 'react-bootstrap';
 
 interface TherapyRecommendationFormEvidenceLevelInputProps {
     data: ITherapyRecommendation;
     onChange: (evidenceLevel: EvidenceLevel) => void;
+    onChangeExtension: (evidenceLevelExtension: EvidenceLevelExtension) => void;
 }
 
 type MyOption = { label: string; value: string };
 
 export default class TherapyRecommendationFormEvidenceLevelInput extends React.Component<
     TherapyRecommendationFormEvidenceLevelInputProps,
-    {}
+    {
+        isM3Disabled: boolean;
+        isM1Disabled: boolean;
+        isValue: boolean;
+        ivValue: boolean;
+        rValue: boolean;
+        zValue: {};
+    }
 > {
+    constructor(props: TherapyRecommendationFormEvidenceLevelInputProps) {
+        super(props);
+
+        this.state = {
+            isM3Disabled:
+                this.props.data.evidenceLevel.toString() !==
+                EvidenceLevel[EvidenceLevel.m3].toString(),
+            isM1Disabled: !this.props.data.evidenceLevel.toString().match('m1'),
+            isValue:
+                this.props.data.evidenceLevelExtension.toString() ==
+                EvidenceLevelExtension.IS,
+            ivValue:
+                this.props.data.evidenceLevelExtension.toString() ===
+                EvidenceLevelExtension.IV,
+            rValue:
+                this.props.data.evidenceLevelExtension.toString() ===
+                EvidenceLevelExtension.R,
+            zValue:
+                this.props.data.evidenceLevelExtension ===
+                    EvidenceLevelExtension.ZFDA ||
+                this.props.data.evidenceLevelExtension ===
+                    EvidenceLevelExtension.ZEMA
+                    ? {
+                          label: this.props.data.evidenceLevelExtension,
+                          value: this.props.data.evidenceLevelExtension,
+                      }
+                    : {},
+        };
+    }
     public render() {
         const Option = (props: any) => {
             return (
@@ -57,27 +96,131 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                 label: value,
                 value: key,
             }));
+        const evidenceLevelApprovalOptions = Object.entries(
+            EvidenceLevelExtension
+        )
+            .filter(
+                ([key, value]) =>
+                    typeof value === 'string' && value.startsWith('Z')
+            )
+            .map(([key, value]) => ({
+                label: value,
+                value: key,
+            }));
+
+        const setExtension = (extension: EvidenceLevelExtension) => {
+            this.setState({
+                isValue: false,
+                ivValue: false,
+                rValue: false,
+                zValue: {},
+            });
+            this.props.onChangeExtension(extension);
+        };
 
         return (
-            <Select
-                options={evidenceLevelOptions}
-                defaultValue={evidenceLevelDefault}
-                components={{ Option }}
-                name="evidenceLevel"
-                className="basic-select"
-                classNamePrefix="select"
-                onChange={(selectedOption: MyOption) => {
-                    this.props.onChange(
-                        EvidenceLevel[
-                            selectedOption.value as keyof typeof EvidenceLevel
-                        ]
-                    );
-                    // therapyRecommendation.evidenceLevel =
-                    //     EvidenceLevel[
-                    //         selectedOption.value as keyof typeof EvidenceLevel
-                    //     ];
-                }}
-            />
+            <Row>
+                <Col xs={3}>
+                    <Select
+                        options={evidenceLevelOptions}
+                        defaultValue={evidenceLevelDefault}
+                        components={{ Option }}
+                        name="evidenceLevel"
+                        className="basic-select"
+                        classNamePrefix="select"
+                        onChange={(selectedOption: MyOption) => {
+                            this.props.onChange(
+                                EvidenceLevel[
+                                    selectedOption.value as keyof typeof EvidenceLevel
+                                ]
+                            );
+                            this.props.onChangeExtension(
+                                EvidenceLevelExtension.NA
+                            );
+                            this.setState({
+                                isM3Disabled:
+                                    this.props.data.evidenceLevel.toString() !==
+                                    EvidenceLevel[EvidenceLevel.m3].toString(),
+                                isM1Disabled: !this.props.data.evidenceLevel
+                                    .toString()
+                                    .match('m1'),
+                                isValue: false,
+                                ivValue: false,
+                                rValue: false,
+                                zValue: {},
+                            });
+                            console.log(
+                                !this.props.data.evidenceLevel
+                                    .toString()
+                                    .match('m1')
+                            );
+                        }}
+                    />
+                </Col>
+                <Col xs={3}>
+                    <Select
+                        options={evidenceLevelApprovalOptions}
+                        isDisabled={this.state.isM1Disabled}
+                        defaultValue={{ label: '', value: '' }}
+                        onChange={(selectedOption: MyOption) => {
+                            setExtension(
+                                EvidenceLevelExtension[
+                                    selectedOption.value as keyof typeof EvidenceLevelExtension
+                                ]
+                            );
+                            this.setState({ zValue: selectedOption });
+                        }}
+                        value={this.state.zValue}
+                        name="evidenceLevelApproval"
+                        className="basic-select"
+                        classNamePrefix="select"
+                    />
+                </Col>
+                <Col xs={2}>
+                    <Checkbox
+                        default={false}
+                        name="evidenceLevelIs"
+                        disabled={this.state.isM3Disabled}
+                        checked={this.state.isValue}
+                        onChange={() => {
+                            setExtension(EvidenceLevelExtension.IS);
+                            this.setState({ isValue: !this.state.isValue });
+                        }}
+                        inline={true}
+                    >
+                        is
+                    </Checkbox>
+                </Col>
+                <Col xs={2}>
+                    <Checkbox
+                        default={false}
+                        name="evidenceLevelIv"
+                        disabled={this.state.isM3Disabled}
+                        checked={this.state.ivValue}
+                        onChange={() => {
+                            setExtension(EvidenceLevelExtension.IV);
+                            this.setState({ ivValue: !this.state.ivValue });
+                        }}
+                        inline={true}
+                    >
+                        iv
+                    </Checkbox>
+                </Col>
+                <Col xs={2}>
+                    <Checkbox
+                        default={false}
+                        inline={true}
+                        name="evidenceLevelR"
+                        checked={this.state.rValue}
+                        onChange={() => {
+                            setExtension(EvidenceLevelExtension.R);
+                            this.setState({ rValue: !this.state.rValue });
+                        }}
+                    >
+                        R
+                    </Checkbox>
+                </Col>
+            </Row>
         );
     }
 }

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
@@ -121,7 +121,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
             this.props.onChangeExtension(extension);
         };
 
-        const changeme = (e: any) => {
+        const onChangeM3Text = (e: any) => {
             this.setState({ m3Text: e.target.value });
             this.props.onChangeM3Text(e.target.value);
         };
@@ -145,6 +145,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                             this.props.onChangeExtension(
                                 EvidenceLevelExtension.NA
                             );
+                            this.props.onChangeM3Text('');
                             this.setState({
                                 isM3Disabled:
                                     this.props.data.evidenceLevel.toString() !==
@@ -156,6 +157,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                                 ivValue: false,
                                 rValue: false,
                                 zValue: {},
+                                m3Text: '',
                             });
                         }}
                     />
@@ -220,7 +222,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                             disabled={
                                 !this.state.isValue && !this.state.ivValue
                             }
-                            onChange={changeme}
+                            onChange={onChangeM3Text}
                             value={this.state.m3Text}
                         />
                     ) : (

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
@@ -13,12 +13,13 @@ import {
     DefaultTooltip,
     placeArrowBottomLeft,
 } from 'cbioportal-frontend-commons';
-import { Checkbox, Col, Row } from 'react-bootstrap';
+import { Checkbox, Col, Form, FormControl, Row } from 'react-bootstrap';
 
 interface TherapyRecommendationFormEvidenceLevelInputProps {
     data: ITherapyRecommendation;
     onChange: (evidenceLevel: EvidenceLevel) => void;
     onChangeExtension: (evidenceLevelExtension: EvidenceLevelExtension) => void;
+    onChangeM3Text: (text: string) => void;
 }
 
 type MyOption = { label: string; value: string };
@@ -30,6 +31,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
         isM1Disabled: boolean;
         isValue: boolean;
         ivValue: boolean;
+        m3Text: string;
         rValue: boolean;
         zValue: {};
     }
@@ -48,6 +50,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
             ivValue:
                 this.props.data.evidenceLevelExtension.toString() ===
                 EvidenceLevelExtension.IV,
+            m3Text: this.props.data.evidenceLevelM3Text,
             rValue:
                 this.props.data.evidenceLevelExtension.toString() ===
                 EvidenceLevelExtension.R,
@@ -118,6 +121,11 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
             this.props.onChangeExtension(extension);
         };
 
+        const changeme = (e: any) => {
+            this.setState({ m3Text: e.target.value });
+            this.props.onChangeM3Text(e.target.value);
+        };
+
         return (
             <Row>
                 <Col xs={3}>
@@ -149,31 +157,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                                 rValue: false,
                                 zValue: {},
                             });
-                            console.log(
-                                !this.props.data.evidenceLevel
-                                    .toString()
-                                    .match('m1')
-                            );
                         }}
-                    />
-                </Col>
-                <Col xs={3}>
-                    <Select
-                        options={evidenceLevelApprovalOptions}
-                        isDisabled={this.state.isM1Disabled}
-                        defaultValue={{ label: '', value: '' }}
-                        onChange={(selectedOption: MyOption) => {
-                            setExtension(
-                                EvidenceLevelExtension[
-                                    selectedOption.value as keyof typeof EvidenceLevelExtension
-                                ]
-                            );
-                            this.setState({ zValue: selectedOption });
-                        }}
-                        value={this.state.zValue}
-                        name="evidenceLevelApproval"
-                        className="basic-select"
-                        classNamePrefix="select"
                     />
                 </Col>
                 <Col xs={2}>
@@ -187,8 +171,20 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                             this.setState({ isValue: !this.state.isValue });
                         }}
                         inline={true}
+                        className={styles['checkbox-align']}
                     >
-                        is
+                        is&nbsp;
+                        <DefaultTooltip
+                            placement="bottomLeft"
+                            trigger={['hover', 'focus']}
+                            overlay={getTooltipEvidenceContent('is')}
+                            destroyTooltipOnHide={false}
+                            onPopupAlign={placeArrowBottomLeft}
+                        >
+                            <i
+                                className={'fa fa-info-circle ' + styles.icon}
+                            ></i>
+                        </DefaultTooltip>
                     </Checkbox>
                 </Col>
                 <Col xs={2}>
@@ -202,9 +198,51 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                             this.setState({ ivValue: !this.state.ivValue });
                         }}
                         inline={true}
+                        className={styles['checkbox-align']}
                     >
-                        iv
+                        iv&nbsp;
+                        <DefaultTooltip
+                            placement="bottomLeft"
+                            trigger={['hover', 'focus']}
+                            overlay={getTooltipEvidenceContent('iv')}
+                            destroyTooltipOnHide={false}
+                            onPopupAlign={placeArrowBottomLeft}
+                        >
+                            <i
+                                className={'fa fa-info-circle ' + styles.icon}
+                            ></i>
+                        </DefaultTooltip>
                     </Checkbox>
+                </Col>
+                <Col xs={3}>
+                    {this.props.data.evidenceLevel.toString() == 'm3' ? (
+                        <FormControl
+                            disabled={
+                                !this.state.isValue && !this.state.ivValue
+                            }
+                            onChange={changeme}
+                            value={this.state.m3Text}
+                        />
+                    ) : (
+                        <Select
+                            options={evidenceLevelApprovalOptions}
+                            isDisabled={this.state.isM1Disabled}
+                            components={{ Option }}
+                            defaultValue={{ label: '', value: '' }}
+                            onChange={(selectedOption: MyOption) => {
+                                setExtension(
+                                    EvidenceLevelExtension[
+                                        selectedOption.value as keyof typeof EvidenceLevelExtension
+                                    ]
+                                );
+                                this.setState({ zValue: selectedOption });
+                            }}
+                            value={this.state.zValue}
+                            name="evidenceLevelApproval"
+                            className="basic-select"
+                            classNamePrefix="select"
+                        />
+                    )}
                 </Col>
                 <Col xs={2}>
                     <Checkbox
@@ -216,8 +254,20 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                             setExtension(EvidenceLevelExtension.R);
                             this.setState({ rValue: !this.state.rValue });
                         }}
+                        className={styles['checkbox-align']}
                     >
-                        R
+                        R&nbsp;
+                        <DefaultTooltip
+                            placement="bottomLeft"
+                            trigger={['hover', 'focus']}
+                            overlay={getTooltipEvidenceContent('R')}
+                            destroyTooltipOnHide={false}
+                            onPopupAlign={placeArrowBottomLeft}
+                        >
+                            <i
+                                className={'fa fa-info-circle ' + styles.icon}
+                            ></i>
+                        </DefaultTooltip>
                     </Checkbox>
                 </Col>
             </Row>

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
@@ -29,6 +29,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
     {
         isM3Disabled: boolean;
         isM1Disabled: boolean;
+        isRDisabled: boolean;
         isValue: boolean;
         ivValue: boolean;
         m3Text: string;
@@ -38,12 +39,15 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
 > {
     constructor(props: TherapyRecommendationFormEvidenceLevelInputProps) {
         super(props);
-
+        console.log(this.props.data.evidenceLevel.toString());
         this.state = {
             isM3Disabled:
                 this.props.data.evidenceLevel.toString() !==
                 EvidenceLevel[EvidenceLevel.m3].toString(),
             isM1Disabled: !this.props.data.evidenceLevel.toString().match('m1'),
+            isRDisabled:
+                this.props.data.evidenceLevel.toString() === 'NA' ||
+                this.props.data.evidenceLevel.toString() === '0',
             isValue:
                 this.props.data.evidenceLevelExtension.toString() ==
                 EvidenceLevelExtension.IS,
@@ -153,6 +157,9 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                                 isM1Disabled: !this.props.data.evidenceLevel
                                     .toString()
                                     .match('m1'),
+                                isRDisabled:
+                                    this.props.data.evidenceLevel.toString() ===
+                                    'NA',
                                 isValue: false,
                                 ivValue: false,
                                 rValue: false,
@@ -251,6 +258,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                         default={false}
                         inline={true}
                         name="evidenceLevelR"
+                        disabled={this.state.isRDisabled}
                         checked={this.state.rValue}
                         onChange={() => {
                             setExtension(EvidenceLevelExtension.R);

--- a/src/pages/patientView/therapyRecommendation/style/therapyRecommendation.module.scss
+++ b/src/pages/patientView/therapyRecommendation/style/therapyRecommendation.module.scss
@@ -189,9 +189,9 @@
     box-shadow: 10px 15px 40px -16px rgb(50, 50, 50);
     background-color: #90cd3c;
     font-size: 20px;
-    z-index:99999999;
+    z-index: 99999999;
     padding: 20px 20px 20px 20px;
-    box-sizing:border-box;
+    box-sizing: border-box;
     color: #000000;
     position: fixed;
     top: 50px;
@@ -200,6 +200,10 @@
     font-weight: 400;
     line-height: 14px;
     text-align: center;
+}
+
+.checkbox-align {
+    margin-top: 8px;
 }
 
 /*

--- a/src/pages/patientView/therapyRecommendation/style/therapyRecommendation.module.scss.d.ts
+++ b/src/pages/patientView/therapyRecommendation/style/therapyRecommendation.module.scss.d.ts
@@ -4,6 +4,7 @@ declare const styles: {
   readonly "addOncoKbButton": string;
   readonly "alterationUl": string;
   readonly "armDiv": string;
+  readonly "checkbox-align": string;
   readonly "criteriaHr": string;
   readonly "deleteButton": string;
   readonly "deleteMtbButton": string;

--- a/src/shared/model/TherapyRecommendation.ts
+++ b/src/shared/model/TherapyRecommendation.ts
@@ -49,6 +49,7 @@ export interface ITherapyRecommendation {
     reasoning: IReasoning;
     evidenceLevel: EvidenceLevel;
     evidenceLevelExtension: EvidenceLevelExtension;
+    evidenceLevelM3Text: string;
     author: string;
     treatments: ITreatment[];
     references: IReference[];

--- a/src/shared/model/TherapyRecommendation.ts
+++ b/src/shared/model/TherapyRecommendation.ts
@@ -10,6 +10,15 @@ export enum EvidenceLevel {
     m4,
 }
 
+export enum EvidenceLevelExtension {
+    NA = '',
+    IS = 'is',
+    IV = 'iv',
+    R = 'R',
+    ZFDA = 'Z(FDA)',
+    ZEMA = 'Z(EMA)',
+}
+
 export enum MtbState {
     PARTIAL = 'Partial',
     PRELIMINARY = 'Preliminary',
@@ -39,6 +48,7 @@ export interface ITherapyRecommendation {
     comment: string[];
     reasoning: IReasoning;
     evidenceLevel: EvidenceLevel;
+    evidenceLevelExtension: EvidenceLevelExtension;
     author: string;
     treatments: ITreatment[];
     references: IReference[];


### PR DESCRIPTION
Added extensions of evidence level according to the [report](https://sozialministerium.baden-wuerttemberg.de/fileadmin/redaktion/m-sm/intern/downloads/Downloads_Krankenh%C3%A4user/Fachplanung_ZPM_28-03-2019.pdf) on page 33. 

You can select one of the four options.
However: Approval state is only available if m1* is selected.
Selecting m3 converts the select field into a text field where the supporting method can be entered.

See following screenshots:

For m1*
![Screenshot 2022-01-19 at 16 05 49](https://user-images.githubusercontent.com/20756025/150159702-5e16181a-9036-47db-a4f5-1956dea62e21.png)

For m3
![Screenshot 2022-01-19 at 16 05 21](https://user-images.githubusercontent.com/20756025/150159722-9236f44c-1226-4739-9034-fb9ee5b7f6d4.png)

However, this change also requires an update to FhirSpark which is avilable with (nr23730/fhirspark#200).