### PR TITLE
Disable editing of MTBs only when they are fetched in state 'final' or saved

### DIFF
--- a/src/pages/patientView/therapyRecommendation/MtbTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTable.tsx
@@ -15,7 +15,6 @@ import {
     flattenStringify,
     getAuthor,
     getTooltipAuthorContent,
-    finalStateHandler,
 } from './TherapyRecommendationTableUtils';
 import { Button } from 'react-bootstrap';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
@@ -191,24 +190,23 @@ export default class MtbTable extends React.Component<IMtbProps, IMtbState> {
                             style={{ marginLeft: 2 }}
                             disabled={
                                 (this.isDisabled(mtb) &&
-                                    finalStateHandler.getState(mtb.id) ===
-                                        false) ||
+                                    !(
+                                        sessionStorage.getItem(mtb.id) ===
+                                        MtbState.FINAL.toUpperCase()
+                                    )) ||
                                 !this.state.permission
                             }
                             onChange={(
                                 e: React.ChangeEvent<HTMLSelectElement>
                             ) => {
                                 const newState = e.target.value;
+                                sessionStorage.setItem(mtb.id, newState);
                                 if (newState === MtbState.FINAL.toUpperCase())
                                     if (
                                         !window.confirm(
                                             'Are you sure you wish to finalize this MTB session to disable editing?'
                                         )
                                     ) {
-                                        finalStateHandler.setState(
-                                            mtb.id,
-                                            true
-                                        );
                                         const newMtbs = this.state.mtbs.slice();
                                         e.target.value = newMtbs.find(
                                             x => x.id === mtb.id
@@ -602,7 +600,12 @@ export default class MtbTable extends React.Component<IMtbProps, IMtbState> {
                             type="button"
                             className={'btn btn-default ' + styles.testButton}
                             disabled={!this.state.permission}
-                            onClick={() => this.saveMtbs()}
+                            onClick={() => {
+                                this.saveMtbs();
+                                this.state.mtbs.forEach((mtb: IMtb) =>
+                                    sessionStorage.removeItem(mtb.id)
+                                );
+                            }}
                         >
                             Save Data
                         </Button>
@@ -638,8 +641,8 @@ export default class MtbTable extends React.Component<IMtbProps, IMtbState> {
         // console.log('cDM got invoked');
         this.props.checkPermission().then(res => {
             console.log('checkPermission returned with ' + res);
-            this.setState({ loggedIn: res[0] });
-            this.setState({ permission: res[1] });
+            this.setState({ loggedIn: true });
+            this.setState({ permission: true });
         });
     }
 }

--- a/src/pages/patientView/therapyRecommendation/MtbTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTable.tsx
@@ -15,6 +15,7 @@ import {
     flattenStringify,
     getAuthor,
     getTooltipAuthorContent,
+    finalStateHandler,
 } from './TherapyRecommendationTableUtils';
 import { Button } from 'react-bootstrap';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
@@ -189,7 +190,10 @@ export default class MtbTable extends React.Component<IMtbProps, IMtbState> {
                             defaultValue={mtb.mtbState}
                             style={{ marginLeft: 2 }}
                             disabled={
-                                this.isDisabled(mtb) || !this.state.permission
+                                (this.isDisabled(mtb) &&
+                                    finalStateHandler.getState(mtb.id) ===
+                                        false) ||
+                                !this.state.permission
                             }
                             onChange={(
                                 e: React.ChangeEvent<HTMLSelectElement>
@@ -201,6 +205,10 @@ export default class MtbTable extends React.Component<IMtbProps, IMtbState> {
                                             'Are you sure you wish to finalize this MTB session to disable editing?'
                                         )
                                     ) {
+                                        finalStateHandler.setState(
+                                            mtb.id,
+                                            true
+                                        );
                                         const newMtbs = this.state.mtbs.slice();
                                         e.target.value = newMtbs.find(
                                             x => x.id === mtb.id

--- a/src/pages/patientView/therapyRecommendation/MtbTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTable.tsx
@@ -641,8 +641,8 @@ export default class MtbTable extends React.Component<IMtbProps, IMtbState> {
         // console.log('cDM got invoked');
         this.props.checkPermission().then(res => {
             console.log('checkPermission returned with ' + res);
-            this.setState({ loggedIn: true });
-            this.setState({ permission: true });
+            this.setState({ loggedIn: res[0] });
+            this.setState({ permission: res[1] });
         });
     }
 }

--- a/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
+++ b/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
@@ -11,6 +11,27 @@ import styles from './style/therapyRecommendation.module.scss';
 import { If, Then, Else } from 'react-if';
 import { getServerConfig } from 'config/config';
 
+interface Dict<T> {
+    [key: string]: T;
+}
+
+export var finalStateHandler = (function() {
+    var finalizedThisSession: Dict<boolean> = {};
+
+    var getState = function(id: string) {
+        return finalizedThisSession[id];
+    };
+
+    var setState = function(id: string, state: boolean) {
+        finalizedThisSession[id] = state;
+    };
+
+    return {
+        getState: getState,
+        setState: setState,
+    };
+})();
+
 export function truncate(
     s: string | undefined,
     n: number,

--- a/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
+++ b/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
@@ -11,27 +11,6 @@ import styles from './style/therapyRecommendation.module.scss';
 import { If, Then, Else } from 'react-if';
 import { getServerConfig } from 'config/config';
 
-interface Dict<T> {
-    [key: string]: T;
-}
-
-export var finalStateHandler = (function() {
-    var finalizedThisSession: Dict<boolean> = {};
-
-    var getState = function(id: string) {
-        return finalizedThisSession[id];
-    };
-
-    var setState = function(id: string, state: boolean) {
-        finalizedThisSession[id] = state;
-    };
-
-    return {
-        getState: getState,
-        setState: setState,
-    };
-})();
-
 export function truncate(
     s: string | undefined,
     n: number,


### PR DESCRIPTION
Implemented a fix for [Issue#39](https://github.com/nr23730/cbioportal-frontend/issues/39)

finalized mtbs are now being stored in sessionStorage and removed once saved