### PR TITLE
show patient display name if available

### DIFF
--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -85,7 +85,7 @@ export class ClinicalDataTab extends React.Component<
         invoke: async () => {
             let defaultColumns: Column<{ [id: string]: string }>[] = [
                 {
-                    ...this.getDefaultColumnConfig('patientId', 'Patient ID'),
+                    ...this.getDefaultColumnConfig('patientId', 'Patient'),
                     render: (data: { [id: string]: string }) => {
                         return (
                             <a
@@ -95,7 +95,15 @@ export class ClinicalDataTab extends React.Component<
                                 )}
                                 target="_blank"
                             >
-                                {data.patientId}
+                                {this.format(
+                                    data.PATIENT_DISPLAY_NAME &&
+                                        data.PATIENT_DISPLAY_NAME !== 'Unknown'
+                                        ? data.PATIENT_DISPLAY_NAME +
+                                              ' (' +
+                                              data.patientId +
+                                              ')'
+                                        : data.patientId
+                                )}
                             </a>
                         );
                     },


### PR DESCRIPTION
This changes the clinical data table of a study from 
![image](https://user-images.githubusercontent.com/20756025/162705157-e68caf7b-55c9-4173-b2b9-d67af0b4502b.png)
to
![Screenshot 2022-04-11 at 11 15 13](https://user-images.githubusercontent.com/20756025/162705292-db4e28a7-3982-4d29-8836-54c1fff02033.png)

I think this is way more convenient for clinicians.
If the display name is not available it defaults back to the patient Id.
