### PR TITLE
Clinical trials as recommendations

### DIFF
--- a/src/pages/patientView/PatientViewPageTabs.tsx
+++ b/src/pages/patientView/PatientViewPageTabs.tsx
@@ -772,6 +772,10 @@ export function tabs(
                         pageComponent.patientViewPageStore.cnaOncoKbData
                     }
                     pubMedCache={pageComponent.patientViewPageStore.pubMedCache}
+                    clinicalTrialClipboard={
+                        pageComponent.patientViewPageStore
+                            .clinicalTrialClipboard
+                    }
                 />
             </MSKTab>
         );
@@ -824,6 +828,7 @@ export function tabs(
                     pageComponent.patientViewPageStore.clinicalTrialMatches
                         .result
                 }
+                mtbTabAvailable={pageComponent.shouldShowMtbTab}
             />
         </MSKTab>
     );

--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -200,7 +200,11 @@ import {
 import { getServerConfig } from 'config/config';
 import { getOncoKbIconStyle } from 'shared/lib/AnnotationColumnUtils';
 
-import { IMtb, IDeletions } from '../../../shared/model/TherapyRecommendation';
+import {
+    IMtb,
+    IDeletions,
+    IClinicalTrial,
+} from '../../../shared/model/TherapyRecommendation';
 import {
     StudyListEntry,
     StudyList,
@@ -2902,6 +2906,10 @@ export class PatientViewPageStore {
             maximumDistance
         );
     }
+
+    @observable
+    public clinicalTrialClipboard: IClinicalTrial[] = [];
+
     readonly oncoKbDataForOncoprint = remoteData<IOncoKbData | Error>(
         {
             await: () => [this.mutationData, this.oncoKbAnnotatedGenes],

--- a/src/pages/patientView/clinicalTrialMatch/ClinicalTrialMatchTable.tsx
+++ b/src/pages/patientView/clinicalTrialMatch/ClinicalTrialMatchTable.tsx
@@ -9,6 +9,8 @@ import LazyMobXTable from '../../../shared/components/lazyMobXTable/LazyMobXTabl
 import ClinicalTrialMatchTableOptions from './ClinicalTrialMatchTableOptions';
 import LoadingIndicator from 'shared/components/loadingIndicator/LoadingIndicator';
 import styles from 'shared/components/loadingIndicator/styles.module.scss';
+import { Button } from 'react-bootstrap';
+import { IClinicalTrial } from 'shared/model/TherapyRecommendation';
 
 enum ColumnKey {
     NUM_FOUND = 'Appearences',
@@ -27,6 +29,7 @@ enum ColumnKey {
 interface IClinicalTrialMatchProps {
     store: PatientViewPageStore;
     clinicalTrialMatches: IDetailedClinicalTrialMatch[];
+    mtbTabAvailable: boolean;
 }
 
 interface ICollapseListState {
@@ -188,7 +191,28 @@ export class ClinicalTrialMatchTable extends React.Component<
         {
             name: ColumnKey.STATUS,
             render: (trial: IDetailedClinicalTrialMatch) => (
-                <div>{trial.status}</div>
+                <div>
+                    {trial.status}
+                    <span>
+                        <Button
+                            type="button"
+                            className={'btn btn-default'}
+                            disabled={!this.props.mtbTabAvailable}
+                            onClick={() =>
+                                this.props.store.clinicalTrialClipboard.push({
+                                    id: trial.nct,
+                                    name: trial.title,
+                                } as IClinicalTrial)
+                            }
+                        >
+                            <i
+                                className={`fa fa-clipboard`}
+                                aria-hidden="true"
+                            ></i>{' '}
+                            MTB Clipboard
+                        </Button>
+                    </span>
+                </div>
             ),
             width: 300,
         },

--- a/src/pages/patientView/therapyRecommendation/MtbTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTable.tsx
@@ -6,6 +6,7 @@ import {
     IMtb,
     MtbState,
     IDeletions,
+    IClinicalTrial,
 } from '../../../shared/model/TherapyRecommendation';
 import { computed, makeObservable, observable } from 'mobx';
 import LazyMobXTable from '../../../shared/components/lazyMobXTable/LazyMobXTable';
@@ -60,6 +61,7 @@ export type IMtbProps = {
     oncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
     cnaOncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
     pubMedCache?: PubMedCache;
+    clinicalTrialClipboard: IClinicalTrial[];
 };
 
 export type IMtbState = {
@@ -372,6 +374,7 @@ export default class MtbTable extends React.Component<IMtbProps, IMtbState> {
                     cnaOncoKbData={this.props.cnaOncoKbData}
                     pubMedCache={this.props.pubMedCache}
                     isDisabled={this.isDisabled(mtb) || !this.state.permission}
+                    clinicalTrialClipboard={this.props.clinicalTrialClipboard}
                 />
             ),
             width: this.columnWidths[ColumnKey.THERAPYRECOMMENDATIONS],

--- a/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
@@ -9,6 +9,7 @@ import {
     IReference,
     IClinicalData,
     EvidenceLevel,
+    IClinicalTrial,
 } from '../../../shared/model/TherapyRecommendation';
 import { computed, makeObservable, observable } from 'mobx';
 import LazyMobXTable from '../../../shared/components/lazyMobXTable/LazyMobXTable';
@@ -76,7 +77,7 @@ export type ITherapyRecommendationState = {
 
 enum ColumnKey {
     PRIO = 'Prio',
-    THERAPY = 'Therapy',
+    THERAPY = 'Therapy / Trials',
     COMMENT = 'Comment',
     REASONING = 'Reasoning',
     REFERENCES = 'References',
@@ -254,29 +255,94 @@ export default class MtbTherapyRecommendationTable extends React.Component<
         {
             name: ColumnKey.THERAPY,
             render: (therapyRecommendation: ITherapyRecommendation) => (
-                <If
-                    condition={
-                        therapyRecommendation.treatments &&
-                        therapyRecommendation.treatments.length > 0
-                    }
-                >
-                    <div>
-                        <span>
-                            {therapyRecommendation.treatments.map(
-                                (treatment: ITreatment) => (
-                                    <div>
-                                        <img
-                                            src={require('../../../globalStyles/images/drug.png')}
-                                            style={{ width: 18, marginTop: -5 }}
-                                            alt="drug icon"
-                                        />
-                                        <b>{treatment.name}</b>
-                                    </div>
-                                )
-                            )}
-                        </span>
-                    </div>
-                </If>
+                <div>
+                    <If
+                        condition={
+                            therapyRecommendation.treatments &&
+                            therapyRecommendation.treatments.length > 0
+                        }
+                    >
+                        <div>
+                            <span>
+                                {therapyRecommendation.treatments.map(
+                                    (treatment: ITreatment) => (
+                                        <div>
+                                            <DefaultTooltip
+                                                placement="bottomLeft"
+                                                trigger={['hover', 'focus']}
+                                                overlay={this.tooltipTreatmentContent(
+                                                    treatment
+                                                )}
+                                                destroyTooltipOnHide={false}
+                                                onPopupAlign={
+                                                    placeArrowBottomLeft
+                                                }
+                                            >
+                                                <i
+                                                    className={
+                                                        'fa fa-medkit ' +
+                                                        styles.icon
+                                                    }
+                                                ></i>
+                                            </DefaultTooltip>
+                                            <span style={{ marginLeft: 5 }}>
+                                                <b>{treatment.name}</b>
+                                            </span>
+                                        </div>
+                                    )
+                                )}
+                            </span>
+                        </div>
+                    </If>
+                    <If
+                        condition={
+                            therapyRecommendation.clinicalTrials &&
+                            therapyRecommendation.clinicalTrials.length > 0
+                        }
+                    >
+                        <div>
+                            <span>
+                                {therapyRecommendation.clinicalTrials.map(
+                                    (clinicalTrial: IClinicalTrial) => (
+                                        <div>
+                                            <DefaultTooltip
+                                                placement="bottomLeft"
+                                                trigger={['hover', 'focus']}
+                                                overlay={this.tooltipClinicalTrialContent(
+                                                    clinicalTrial
+                                                )}
+                                                destroyTooltipOnHide={false}
+                                                onPopupAlign={
+                                                    placeArrowBottomLeft
+                                                }
+                                            >
+                                                <i
+                                                    className={
+                                                        'fa fa-stethoscope ' +
+                                                        styles.icon
+                                                    }
+                                                ></i>
+                                            </DefaultTooltip>
+                                            <span style={{ marginLeft: 5 }}>
+                                                <b>
+                                                    <a
+                                                        href={
+                                                            'https://www.clinicaltrials.gov/ct2/show/' +
+                                                            clinicalTrial.id
+                                                        }
+                                                        target={'_blank'}
+                                                    >
+                                                        {clinicalTrial.id}
+                                                    </a>
+                                                </b>
+                                            </span>
+                                        </div>
+                                    )
+                                )}
+                            </span>
+                        </div>
+                    </If>
+                </div>
             ),
             // width: this.columnWidths[ColumnKey.THERAPY]
         },
@@ -653,6 +719,32 @@ export default class MtbTherapyRecommendationTable extends React.Component<
                     <b>{geneticAlteration.hugoSymbol}</b> (ID:{' '}
                     {geneticAlteration.entrezGeneId}){' '}
                     {geneticAlteration.alteration || 'any'}
+                </div>
+            </div>
+        );
+    }
+
+    private tooltipTreatmentContent(treatment: ITreatment) {
+        return (
+            <div className={styles.tooltip}>
+                <div>
+                    <div>
+                        <b>{treatment.name}</b> (NCIT: {treatment.ncit_code})
+                    </div>
+                    <div>Synonyms: {treatment.synonyms || '-'}</div>
+                </div>
+            </div>
+        );
+    }
+
+    private tooltipClinicalTrialContent(clinicalTrial: IClinicalTrial) {
+        return (
+            <div className={styles.tooltip}>
+                <div>
+                    <div>
+                        <b>{clinicalTrial.id}</b>
+                    </div>
+                    <div>{clinicalTrial.name}</div>
                 </div>
             </div>
         );

--- a/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTherapyRecommendationTable.tsx
@@ -69,6 +69,7 @@ export type ITherapyRecommendationProps = {
     cnaOncoKbData?: RemoteData<IOncoKbData | Error | undefined>;
     pubMedCache?: PubMedCache;
     isDisabled: boolean;
+    clinicalTrialClipboard: IClinicalTrial[];
 };
 
 export type ITherapyRecommendationState = {
@@ -831,6 +832,9 @@ export default class MtbTherapyRecommendationTable extends React.Component<
                         }}
                         title="Edit therapy recommendation"
                         userEmailAddress={getServerConfig().user_email_address}
+                        clinicalTrialClipboard={
+                            this.props.clinicalTrialClipboard
+                        }
                     />
                 )}
                 {this.showOncoKBForm && (

--- a/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
+++ b/src/pages/patientView/therapyRecommendation/TherapyRecommendationTableUtils.tsx
@@ -44,6 +44,7 @@ export function getNewTherapyRecommendation(
         author: getAuthor(),
         references: [],
         treatments: [],
+        clinicalTrials: [],
     };
     return therapyRecommendation;
 }

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationForm.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationForm.tsx
@@ -4,6 +4,7 @@ import { Modal, Button } from 'react-bootstrap';
 import {
     ITherapyRecommendation,
     EvidenceLevel,
+    IClinicalTrial,
 } from 'shared/model/TherapyRecommendation';
 import { TherapyRecommendationFormAlterationInput } from './TherapyRecommendationFormAlterationInput';
 import {
@@ -39,6 +40,7 @@ interface ITherapyRecommendationFormProps {
     title: string;
     userEmailAddress: string;
     onHide: (newTherapyRecommendation?: ITherapyRecommendation) => void;
+    clinicalTrialClipboard: IClinicalTrial[];
 }
 
 export default class TherapyRecommendationForm extends React.Component<
@@ -110,6 +112,9 @@ export default class TherapyRecommendationForm extends React.Component<
                                 data={therapyRecommendation}
                                 onChange={clinicalTrials =>
                                     (therapyRecommendation.clinicalTrials = clinicalTrials)
+                                }
+                                clinicalTrialClipboard={
+                                    this.props.clinicalTrialClipboard
                                 }
                             />
                         </div>

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationForm.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationForm.tsx
@@ -20,6 +20,7 @@ import TherapyRecommendationFormEvidenceLevelInput from './TherapyRecommendation
 import { VariantAnnotation, MyVariantInfo } from 'genome-nexus-ts-api-client';
 import SampleManager from 'pages/patientView/SampleManager';
 import { IMutationalSignature } from 'shared/model/MutationalSignature';
+import TherapyRecommendationFormClinicalTrialInput from './TherapyRecommendationFormClinicalTrialInput';
 
 interface ITherapyRecommendationFormProps {
     show: boolean;
@@ -99,6 +100,16 @@ export default class TherapyRecommendationForm extends React.Component<
                                 data={therapyRecommendation}
                                 onChange={drugs =>
                                     (therapyRecommendation.treatments = drugs)
+                                }
+                            />
+                        </div>
+
+                        <div className="form-group">
+                            <h5>Clinical Trial(s):</h5>
+                            <TherapyRecommendationFormClinicalTrialInput
+                                data={therapyRecommendation}
+                                onChange={clinicalTrials =>
+                                    (therapyRecommendation.clinicalTrials = clinicalTrials)
                                 }
                             />
                         </div>

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormClinicalTrialInput.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormClinicalTrialInput.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+    ITherapyRecommendation,
+    IClinicalTrial,
+} from 'shared/model/TherapyRecommendation';
+import AsyncCreatableSelect from 'react-select/async-creatable';
+import _ from 'lodash';
+import request from 'superagent';
+
+interface TherapyRecommendationFormClinicalTrialInputProps {
+    data: ITherapyRecommendation;
+    onChange: (clinicalTrials: IClinicalTrial[]) => void;
+}
+
+type MyOption = { label: string; value: IClinicalTrial };
+
+export default class TherapyRecommendationFormClinicalTrialInput extends React.Component<
+    TherapyRecommendationFormClinicalTrialInputProps,
+    {}
+> {
+    public render() {
+        const clinicalTrialDefault = this.props.data.clinicalTrials.map(
+            (clinicalTrial: IClinicalTrial) => ({
+                value: clinicalTrial,
+                label: clinicalTrial.id + ': ' + clinicalTrial.name,
+            })
+        );
+        return (
+            <AsyncCreatableSelect
+                isMulti
+                defaultValue={clinicalTrialDefault}
+                cacheOptions
+                placeholder="Enter or search trial title..."
+                name="clinicalTrialsSelect"
+                className="creatable-multi-select"
+                classNamePrefix="select"
+                onChange={(selectedOption: MyOption[]) => {
+                    if (Array.isArray(selectedOption)) {
+                        this.props.onChange(
+                            selectedOption.map(option => {
+                                if (_.isString(option.value)) {
+                                    return {
+                                        id: '',
+                                        name: option.value,
+                                    } as IClinicalTrial;
+                                } else {
+                                    return option.value as IClinicalTrial;
+                                }
+                            })
+                        );
+                    } else if (selectedOption === null) {
+                        this.props.onChange([] as IClinicalTrial[]);
+                    }
+                }}
+                loadOptions={promiseOptions}
+            />
+        );
+    }
+}
+
+const promiseOptions = (
+    inputValue: string,
+    callback: (options: ReadonlyArray<MyOption>) => void
+) =>
+    new Promise<MyOption>((resolve, reject) => {
+        // TODO better to separate this call to a configurable client
+        request
+            .get(
+                'https://www.clinicaltrials.gov/api/query/study_fields?expr=' +
+                    inputValue +
+                    '&fields=NCTId%2CBriefTitle%2COfficialTitle&min_rnk=1&max_rnk=5&fmt=json'
+            )
+            .end((err, res) => {
+                if (!err && res.ok) {
+                    const response = JSON.parse(res.text);
+                    const result = response.result;
+                    const trialResults = result.StudyFieldResponse.Studyfields;
+                    const ret: MyOption[] = trialResults.map(
+                        (trialResult: {
+                            BriefTitle: string;
+                            NCTId: string;
+                        }) => {
+                            const trialName = trialResult.BriefTitle;
+                            const trialId = trialResult.NCTId;
+                            return {
+                                value: {
+                                    name: trialName,
+                                    id: trialId,
+                                },
+                                label: trialId + ': ' + trialName,
+                            } as MyOption;
+                        }
+                    );
+                    return callback(ret);
+                } else {
+                    const errClinicalTrial = {
+                        id: '',
+                        name: 'Could not fetch trial for: ' + inputValue,
+                    };
+                    return callback([
+                        {
+                            value: errClinicalTrial,
+                            label:
+                                errClinicalTrial.id +
+                                ': ' +
+                                errClinicalTrial.name,
+                        },
+                    ]);
+                }
+            });
+    });

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormClinicalTrialInput.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormClinicalTrialInput.tsx
@@ -73,15 +73,20 @@ const promiseOptions = (
             .end((err, res) => {
                 if (!err && res.ok) {
                     const response = JSON.parse(res.text);
-                    const result = response.result;
-                    const trialResults = result.StudyFieldResponse.Studyfields;
+                    const result = response.StudyFieldsResponse;
+                    console.group('Result from ClinicalTrials.gov');
+                    console.log(response);
+                    console.groupEnd();
+                    const trialResults = result.StudyFields;
                     const ret: MyOption[] = trialResults.map(
                         (trialResult: {
-                            BriefTitle: string;
-                            NCTId: string;
+                            OfficialTitle: string[];
+                            BriefTitle: string[];
+                            NCTId: string[];
+                            Rank: number;
                         }) => {
-                            const trialName = trialResult.BriefTitle;
-                            const trialId = trialResult.NCTId;
+                            const trialName = trialResult.BriefTitle[0];
+                            const trialId = trialResult.NCTId[0];
                             return {
                                 value: {
                                     name: trialName,

--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormClinicalTrialInput.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormClinicalTrialInput.tsx
@@ -10,6 +10,7 @@ import request from 'superagent';
 interface TherapyRecommendationFormClinicalTrialInputProps {
     data: ITherapyRecommendation;
     onChange: (clinicalTrials: IClinicalTrial[]) => void;
+    clinicalTrialClipboard: IClinicalTrial[];
 }
 
 type MyOption = { label: string; value: IClinicalTrial };
@@ -19,7 +20,13 @@ export default class TherapyRecommendationFormClinicalTrialInput extends React.C
     {}
 > {
     public render() {
-        const clinicalTrialDefault = this.props.data.clinicalTrials.map(
+        const clinicalTrialDefaultValue = this.props.data.clinicalTrials.map(
+            (clinicalTrial: IClinicalTrial) => ({
+                value: clinicalTrial,
+                label: clinicalTrial.id + ': ' + clinicalTrial.name,
+            })
+        );
+        const clinicalTrialDefaultOptions = this.props.clinicalTrialClipboard.map(
             (clinicalTrial: IClinicalTrial) => ({
                 value: clinicalTrial,
                 label: clinicalTrial.id + ': ' + clinicalTrial.name,
@@ -28,7 +35,7 @@ export default class TherapyRecommendationFormClinicalTrialInput extends React.C
         return (
             <AsyncCreatableSelect
                 isMulti
-                defaultValue={clinicalTrialDefault}
+                defaultValue={clinicalTrialDefaultValue}
                 cacheOptions
                 placeholder="Enter or search trial title..."
                 name="clinicalTrialsSelect"
@@ -53,6 +60,7 @@ export default class TherapyRecommendationFormClinicalTrialInput extends React.C
                     }
                 }}
                 loadOptions={promiseOptions}
+                defaultOptions={clinicalTrialDefaultOptions}
             />
         );
     }

--- a/src/shared/api/TherapyRecommendationAPI.ts
+++ b/src/shared/api/TherapyRecommendationAPI.ts
@@ -187,12 +187,17 @@ export async function checkPermissionUsingGET(url: string, studyId: string) {
                 let boolArray: boolean[] = [true, false];
                 return boolArray;
             } else {
+                let usingLocalhost = url.includes('localhost');
                 console.group(
                     '### MTB ### ERROR checkPermissionUsingGET ' + url
                 );
                 console.log(err);
+                if (usingLocalhost)
+                    console.log(
+                        'The application is running in localhost, therefore editing is enabled.'
+                    );
                 console.groupEnd();
-                let boolArray: boolean[] = [false, false];
+                let boolArray: boolean[] = [false, usingLocalhost];
                 return boolArray;
             }
         });

--- a/src/shared/model/TherapyRecommendation.ts
+++ b/src/shared/model/TherapyRecommendation.ts
@@ -54,6 +54,12 @@ export interface ITherapyRecommendation {
     author: string;
     treatments: ITreatment[];
     references: IReference[];
+    clinicalTrials: IClinicalTrial[];
+}
+
+export interface IClinicalTrial {
+    name: string;
+    id: string;
 }
 
 export interface IReference {


### PR DESCRIPTION
This pull request adds the functionality to add  clinical trials as recommendations in the MTB tab:
- Search trials on ClinicalTrials.gov by trial name in therapy recommendation form
- Store trial in clipboard from ClinicalTrialsGov tab and reuse them in therapy recommendation form
- Display recommended trials together with treatments in therapy recommendation table

Should also fix nr23730/cbioportal-frontend#81

Styling of clipboard button in ClinicalTrialsGov tab needs to be brought in line with changes of #77 

Screenshots:
<img width="1032" alt="Bildschirmfoto 2022-06-01 um 08 38 08" src="https://user-images.githubusercontent.com/33686055/171343181-d3a1d355-23b2-43df-9afa-99874f96ab40.png">

<img width="1032" alt="Bildschirmfoto 2022-06-01 um 08 38 29" src="https://user-images.githubusercontent.com/33686055/171343176-d16cf3b1-a334-41b3-8b46-f6bf2504e355.png">

<img width="1032" alt="Bildschirmfoto 2022-06-01 um 08 38 52" src="https://user-images.githubusercontent.com/33686055/171343171-83414eff-f633-49bb-a6fc-8b8dcba5822b.png">

