### PR TITLE
support gender and sex in clinical trial

### DIFF
--- a/src/pages/patientView/clinicalTrialMatch/ClinicalTrialMatchTableOptions.tsx
+++ b/src/pages/patientView/clinicalTrialMatch/ClinicalTrialMatchTableOptions.tsx
@@ -170,7 +170,7 @@ class ClinicalTrialMatchTableOptions extends React.Component<
                 country: '',
                 admin_name: '',
             },
-            gender: sex || 'All',
+            gender: this.gender ? this.gender.value : null,
             ageState: +parseInt(this.age),
             maxDistance: '',
             isOpened: false,
@@ -681,7 +681,16 @@ class ClinicalTrialMatchTableOptions extends React.Component<
                                                 })
                                             )}
                                             name="genderSearch"
-                                            defaultValue={this.gender}
+                                            defaultValue={
+                                                this.state.gender
+                                                    ? {
+                                                          label: this.state
+                                                              .gender,
+                                                          value: this.state
+                                                              .gender,
+                                                      }
+                                                    : null
+                                            }
                                             className="basic-select"
                                             classNamePrefix="select"
                                             placeholder="Select gender..."

--- a/src/pages/patientView/clinicalTrialMatch/ClinicalTrialMatchTableOptions.tsx
+++ b/src/pages/patientView/clinicalTrialMatch/ClinicalTrialMatchTableOptions.tsx
@@ -91,12 +91,17 @@ class ClinicalTrialMatchTableOptions extends React.Component<
     constructor(props: IClinicalTrialOptionsMatchProps) {
         super(props);
 
-        this.gender = { label: 'All', value: 'All' };
+        this.gender = null;
         let sex = this.props.store.clinicalDataPatient.result.find(
             (attribute: any) => attribute.clinicalAttributeId === 'SEX'
         )?.value;
+        let gender = this.props.store.clinicalDataPatient.result.find(
+            (attribute: any) => attribute.clinicalAttributeId === 'GENDER'
+        )?.value;
         if (sex !== undefined && sex.length > 0) {
             this.gender = { label: sex, value: sex };
+        } else if (gender !== undefined && gender.length > 0) {
+            this.gender = { label: gender, value: gender };
         }
 
         this.age =


### PR DESCRIPTION
Current status: Gender in clinical trial search can only be set using `SEX` attribute. 

This change allows also `GENDER` to set the same. Also the default behavior from inserting `ALL` is changed so that nothing is set by default.