### PR TITLE
update non final order ids

### DIFF
--- a/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
+++ b/src/pages/patientView/clinicalInformation/PatientViewPageStore.ts
@@ -2555,7 +2555,12 @@ export class PatientViewPageStore {
             invoke: () => {
                 return fetchMtbsUsingGET(
                     this.getMtbJsonStoreUrl(this.getSafePatientId()),
-                    this.getSafeStudyId()
+                    this.getSafeStudyId(),
+                    (
+                        this.clinicalDataPatient.result.filter(
+                            e => e.clinicalAttributeId == 'ORDER_ID'
+                        )[0] || { value: '' }
+                    ).value
                 );
             },
         },

--- a/src/shared/api/TherapyRecommendationAPI.ts
+++ b/src/shared/api/TherapyRecommendationAPI.ts
@@ -67,7 +67,11 @@ export async function fetchFollowupUsingGET(url: string) {
         });
 }
 
-export async function fetchMtbsUsingGET(url: string, studyId: string) {
+export async function fetchMtbsUsingGET(
+    url: string,
+    studyId: string,
+    orderId: string
+) {
     url = url + '?studyId=' + studyId;
     console.log('### MTB ### Calling GET: ' + url);
     return request
@@ -83,7 +87,8 @@ export async function fetchMtbsUsingGET(url: string, studyId: string) {
                     (mtb: any) =>
                         ({
                             id: mtb.id,
-                            orderId: mtb.orderId,
+                            orderId:
+                                mtb.mtbState == 'FINAL' ? mtb.orderId : orderId,
                             therapyRecommendations: mtb.therapyRecommendations,
                             geneticCounselingRecommendation:
                                 mtb.geneticCounselingRecommendation,


### PR DESCRIPTION
Problem: A therapy strategy may get documented before all the required clinical data is imported. This could result in old order ids being associated to the MTB session. My proposal here would be to update the order id as long as the status of the MTB is not set to final.