### PR TITLE
make mtb textarea bigger

### DIFF
--- a/src/pages/patientView/therapyRecommendation/MtbTable.tsx
+++ b/src/pages/patientView/therapyRecommendation/MtbTable.tsx
@@ -273,8 +273,8 @@ export default class MtbTable extends React.Component<IMtbProps, IMtbState> {
                     </LabeledCheckbox>
                     <textarea
                         title="Comments"
-                        rows={4}
-                        cols={30}
+                        rows={10}
+                        cols={80}
                         value={mtb.generalRecommendation}
                         placeholder="Comments"
                         disabled={


### PR DESCRIPTION
For us it turns out that the textbox is also used most of the times. Right now this leads to a permanent manual enlarging of that textbox. 
So I would vote for a general enlargement of it.