### PR TITLE
enable drug approval on m2 evidence

### DIFF
--- a/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
+++ b/src/pages/patientView/therapyRecommendation/form/TherapyRecommendationFormEvidenceLevelInput.tsx
@@ -44,7 +44,9 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
             isM3Disabled:
                 this.props.data.evidenceLevel.toString() !==
                 EvidenceLevel[EvidenceLevel.m3].toString(),
-            isM1Disabled: !this.props.data.evidenceLevel.toString().match('m1'),
+            isM1Disabled: !this.props.data.evidenceLevel
+                .toString()
+                .match('m1|m2'),
             isRDisabled:
                 this.props.data.evidenceLevel.toString() === 'NA' ||
                 this.props.data.evidenceLevel.toString() === '0',
@@ -156,7 +158,7 @@ export default class TherapyRecommendationFormEvidenceLevelInput extends React.C
                                     EvidenceLevel[EvidenceLevel.m3].toString(),
                                 isM1Disabled: !this.props.data.evidenceLevel
                                     .toString()
-                                    .match('m1'),
+                                    .match('m1|m2'),
                                 isRDisabled:
                                     this.props.data.evidenceLevel.toString() ===
                                     'NA',


### PR DESCRIPTION
Turned out that there are a few scenarios where it makes sense to have the approval state also available for m2 evidence level, so I added this to the regex...